### PR TITLE
RTMP source: disable video preview when streaming

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -126,6 +126,10 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
             showCameraSelectionDialog()
         }
 
+        binding.switchSourceButton.setOnClickListener {
+            previewViewModel.toggleVideoSource()
+        }
+
         previewViewModel.streamerErrorLiveData.observe(viewLifecycleOwner) {
             showError("Oops", it)
         }

--- a/app/src/main/res/layout/main_fragment.xml
+++ b/app/src/main/res/layout/main_fragment.xml
@@ -49,7 +49,6 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:contentDescription="@string/switch_camera_source"
-                android:onClick="@{() -> viewmodel.toggleVideoSource()}"
                 android:src="@drawable/ic_switch_camera_24px"
                 app:tint="@android:color/white" />
 


### PR DESCRIPTION
ExoPlayer can only render to one surface.
I think this fixes bug when streaming app goes into background and when it comes back it starts rendering to preview and not to output surface.