### PR TITLE
Always show notification buttons

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
@@ -166,6 +166,9 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
                     ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
                 )
             } else {
+                // For older versions, start foreground normally using Service API
+                // (the three-arg ServiceCompat overload resolution can be ambiguous
+                // with newer API shims). We're in a Service subclass so call directly.
                 startForeground(1001, onCreateNotification())
             }
         } catch (t: Throwable) {

--- a/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
@@ -742,22 +742,38 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
     }
 
     override fun onCreateNotification(): Notification {
-        return buildServiceNotification(
+        return customNotificationUtils.createServiceNotification(
+            title = getString(R.string.service_notification_title),
             content = getString(R.string.service_notification_text_created),
-            isStreaming = false,
+            iconResourceId = notificationIconResourceId,
+            isForeground = true,
             showStart = true,
             showStop = false,
-            isForeground = true
+            startPending = startPendingIntent,
+            stopPending = stopPendingIntent,
+            muteLabel = getString(R.string.service_notification_action_mute),
+            mutePending = mutePendingIntent,
+            exitPending = exitPendingIntent,
+            openPending = openPendingIntent
         )
     }
 
     override fun onOpenNotification(): Notification? {
-        return buildServiceNotification(
+        val isMuted = (streamer as? IWithAudioSource)?.audioInput?.isMuted ?: false
+        val muteLabel = if (isMuted) getString(R.string.service_notification_action_unmute) else getString(R.string.service_notification_action_mute)
+        return customNotificationUtils.createServiceNotification(
+            title = getString(R.string.service_notification_title),
             content = getString(R.string.status_streaming),
-            isStreaming = true,
+            iconResourceId = notificationIconResourceId,
+            isForeground = true,
             showStart = false,
             showStop = true,
-            isForeground = true
+            startPending = startPendingIntent,
+            stopPending = stopPendingIntent,
+            muteLabel = muteLabel,
+            mutePending = mutePendingIntent,
+            exitPending = exitPendingIntent,
+            openPending = openPendingIntent
         )
     }
 
@@ -768,76 +784,38 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
         try {
             serviceScope.launch { _criticalErrors.emit(errorMessage) }
         } catch (_: Throwable) {}
-        return buildServiceNotification(
+        return customNotificationUtils.createServiceNotification(
+            title = getString(R.string.service_notification_title),
             content = errorMessage,
-            isStreaming = false,
+            iconResourceId = notificationIconResourceId,
+            isForeground = false,
             showStart = true,
             showStop = false,
-            isForeground = false
+            startPending = startPendingIntent,
+            stopPending = stopPendingIntent,
+            muteLabel = getString(R.string.service_notification_action_mute),
+            mutePending = mutePendingIntent,
+            exitPending = exitPendingIntent,
+            openPending = openPendingIntent
         )
     }
 
     override fun onCloseNotification(): Notification? {
-        return buildServiceNotification(
+        return customNotificationUtils.createServiceNotification(
+            title = getString(R.string.service_notification_title),
             content = getString(R.string.status_not_streaming),
-            isStreaming = false,
+            iconResourceId = notificationIconResourceId,
+            isForeground = false,
             showStart = true,
             showStop = false,
-            isForeground = false
+            startPending = startPendingIntent,
+            stopPending = stopPendingIntent,
+            muteLabel = getString(R.string.service_notification_action_mute),
+            mutePending = mutePendingIntent,
+            exitPending = exitPendingIntent,
+            openPending = openPendingIntent
         )
     }
 
-    /**
-     * Helper to build a consistent notification with common attributes and actions.
-     */
-    private fun buildServiceNotification(
-        content: String?,
-        isStreaming: Boolean,
-        showStart: Boolean,
-        showStop: Boolean,
-        isForeground: Boolean
-    ): Notification {
-        val openPending = openPendingIntent
-        val startPending = startPendingIntent
-        val stopPending = stopPendingIntent
-        val mutePending = mutePendingIntent
-        val exitPending = exitPendingIntent
-
-        val builder = NotificationCompat.Builder(this, "camera_streaming_channel").apply {
-            setSmallIcon(notificationIconResourceId)
-            val title = try { getString(R.string.service_notification_title) } catch (_: Throwable) { null }
-            val appLabel = try { applicationInfo.loadLabel(packageManager).toString() } catch (_: Throwable) { null }
-            if (title != null && (appLabel == null || title != appLabel)) setContentTitle(title)
-            setContentIntent(openPending)
-            content?.let { setContentText(it) }
-
-            if (isForeground) {
-                priority = NotificationCompat.PRIORITY_HIGH
-                setOngoing(true)
-                setAutoCancel(false)
-                setShowWhen(true)
-                setUsesChronometer(true)
-                setCategory(NotificationCompat.CATEGORY_SERVICE)
-                setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
-                setLocalOnly(true)
-            } else {
-                setOngoing(false)
-            }
-
-            if (showStop) addAction(notificationIconResourceId, "Stop", stopPending)
-            if (showStart) addAction(notificationIconResourceId, "Start", startPending)
-            // Always show mute/unmute and exit actions so users can control audio and exit
-            val muteLabel = if ((streamer as? IWithAudioSource)?.audioInput?.isMuted == true) getString(R.string.service_notification_action_unmute) else getString(R.string.service_notification_action_mute)
-            addAction(notificationIconResourceId, muteLabel, mutePending)
-            addAction(notificationIconResourceId, getString(R.string.service_notification_action_exit), exitPending)
-
-            setOnlyAlertOnce(true)
-            setSound(null)
-            setVibrate(null)
-            setLights(0, 0, 0)
-            setDefaults(0)
-        }
-
-        return builder.build()
-    }
+    // Notification creation delegated to NotificationUtils.createServiceNotification
 }

--- a/app/src/main/java/com/dimadesu/lifestreamer/services/utils/NotificationUtils.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/services/utils/NotificationUtils.kt
@@ -118,35 +118,6 @@ class NotificationUtils(
         return builder.build()
     }
 
-    /**
-     * Create a small transient notification that always sets the content title
-     * to ensure it replaces previous notification header content.
-     */
-    fun createTransientNotification(
-        title: String,
-        content: String? = null,
-        @DrawableRes iconResourceId: Int
-    ): Notification {
-        val builder = NotificationCompat.Builder(service, channelId).apply {
-            setSmallIcon(iconResourceId)
-            // Use the provided content as the primary notification title so the
-            // system doesn't reuse an older header (which previously caused the
-            // 'Live' label to briefly appear). If content is null, fall back to
-            // the supplied title.
-            val primary = content ?: title
-            primary?.let { setContentTitle(it) }
-            // Only set content text when it's different from the primary title
-            if (content != null && content != primary) setContentText(content)
-            setOnlyAlertOnce(true)
-            setSound(null)
-            setVibrate(null)
-            setLights(0, 0, 0)
-            setDefaults(0)
-            setAutoCancel(true)
-            setOngoing(false)
-        }
-        return builder.build()
-    }
 
     fun createNotificationChannel(
         @StringRes nameResourceId: Int,

--- a/app/src/main/java/com/dimadesu/lifestreamer/services/utils/NotificationUtils.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/services/utils/NotificationUtils.kt
@@ -127,8 +127,6 @@ class NotificationUtils(
         content: String? = null,
         @DrawableRes iconResourceId: Int
     ): Notification {
-        // Diagnostic: log transient notification creation
-        try { android.util.Log.d("CameraStreamerService", "NotificationUtils.createTransientNotification: title='${title}', content='${content}'") } catch (_: Throwable) {}
         val builder = NotificationCompat.Builder(service, channelId).apply {
             setSmallIcon(iconResourceId)
             // Use the provided content as the primary notification title so the

--- a/app/src/main/java/com/dimadesu/lifestreamer/services/utils/NotificationUtils.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/services/utils/NotificationUtils.kt
@@ -26,7 +26,6 @@ import android.os.Build
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.core.app.NotificationCompat
-import androidx.core.app.ServiceCompat
 import com.dimadesu.lifestreamer.ui.main.MainActivity
 
 /**
@@ -43,28 +42,8 @@ class NotificationUtils(
         service.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
     }
 
-    fun cancel() {
-        notificationManager.cancel(notificationId)
-    }
-
     fun notify(notification: Notification) {
         notificationManager.notify(notificationId, notification)
-    }
-
-    fun createNotification(
-        @StringRes titleResourceId: Int,
-        @StringRes contentResourceId: Int,
-        @DrawableRes iconResourceId: Int
-    ): Notification {
-        return createNotification(
-            service.getString(titleResourceId),
-            if (contentResourceId != 0) {
-                service.getString(contentResourceId)
-            } else {
-                null
-            },
-            iconResourceId
-        )
     }
 
     fun createNotification(
@@ -136,6 +115,33 @@ class NotificationUtils(
             setDefaults(0)
         }
 
+        return builder.build()
+    }
+
+    /**
+     * Create a small transient notification that always sets the content title
+     * to ensure it replaces previous notification header content.
+     */
+    fun createTransientNotification(
+        title: String,
+        content: String? = null,
+        @DrawableRes iconResourceId: Int
+    ): Notification {
+        // Diagnostic: log transient notification creation
+        try { android.util.Log.d("CameraStreamerService", "NotificationUtils.createTransientNotification: title='${title}', content='${content}'") } catch (_: Throwable) {}
+        val builder = NotificationCompat.Builder(service, channelId).apply {
+            setSmallIcon(iconResourceId)
+            // Force the content title to avoid residual header text from previous notifications
+            setContentTitle(title)
+            content?.let { setContentText(it) }
+            setOnlyAlertOnce(true)
+            setSound(null)
+            setVibrate(null)
+            setLights(0, 0, 0)
+            setDefaults(0)
+            setAutoCancel(true)
+            setOngoing(false)
+        }
         return builder.build()
     }
 

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -874,13 +874,11 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
     fun setMute(isMuted: Boolean) {
         // Perform mute operations off the main thread to avoid blocking UI.
         viewModelScope.launch(Dispatchers.Default) {
-            Log.d(TAG, "setMute called: isMuted=$isMuted, streamerService=${streamerService != null}")
             // Prefer calling the bound service to centralize mutation and notification updates
             val svc = streamerService
             if (svc != null) {
                 try {
                     svc.setMuted(isMuted)
-                    Log.d(TAG, "setMute: invoked service.setMuted($isMuted)")
                     return@launch
                 } catch (t: Throwable) {
                     Log.w(TAG, "Failed to set mute via service: ${t.message}")

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -874,11 +874,13 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
     fun setMute(isMuted: Boolean) {
         // Perform mute operations off the main thread to avoid blocking UI.
         viewModelScope.launch(Dispatchers.Default) {
+            Log.d(TAG, "setMute called: isMuted=$isMuted, streamerService=${streamerService != null}")
             // Prefer calling the bound service to centralize mutation and notification updates
             val svc = streamerService
             if (svc != null) {
                 try {
                     svc.setMuted(isMuted)
+                    Log.d(TAG, "setMute: invoked service.setMuted($isMuted)")
                     return@launch
                 } catch (t: Throwable) {
                     Log.w(TAG, "Failed to set mute via service: ${t.message}")

--- a/app/src/main/res/drawable/ic_toggle_mic_button.xml
+++ b/app/src/main/res/drawable/ic_toggle_mic_button.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@drawable/ic_baseline_mic_24" android:state_checked="true" />
-    <item android:drawable="@drawable/ic_baseline_mic_off_24" android:state_checked="false" />
+    <item android:drawable="@drawable/ic_baseline_mic_24" android:state_checked="false" />
+    <item android:drawable="@drawable/ic_baseline_mic_off_24" android:state_checked="true" />
 </selector>

--- a/app/src/main/res/layout/main_fragment.xml
+++ b/app/src/main/res/layout/main_fragment.xml
@@ -200,6 +200,7 @@
                 android:layout_height="wrap_content"
                 android:contentDescription="@string/mute_unmute_microphone"
                 android:drawableTop="@drawable/ic_toggle_mic_button"
+                android:checked="@{viewmodel.isMutedLiveData}"
                 android:onCheckedChanged="@{(_, checked) -> viewmodel.setMute(checked)}"
                 android:textOff=""
                 android:textOn=""

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,7 +22,7 @@
     <!-- Notification action labels -->
     <string name="service_notification_action_mute">Mute</string>
     <string name="service_notification_action_unmute">Unmute</string>
-    <string name="service_notification_action_exit">Exit</string>
+    <string name="service_notification_action_exit">Quit</string>
 
     <!-- Preview -->
     <string name="live">Start Live</string>


### PR DESCRIPTION
A lot happening in this PR actually.

- Always show all buttons in notification.
- Made mute/unmute logic work as expected.
  - Synced up states between UI and notification.
  - Notification was showing live status incorrectly on mute/unmute when not streaming. Fixed that.
- I started getting ANR (app not responsive) mid-PR, looks like I fixed it in the end.
- Rename `Exit` to `Quit`