### PR TITLE
Fix closed error dialog displayed again on orientation change

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -120,12 +120,18 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
             previewViewModel.toggleVideoSource(mediaProjectionLauncher)
         }
 
-        previewViewModel.streamerErrorLiveData.observe(viewLifecycleOwner) {
-            showError("Oops", it)
+        previewViewModel.streamerErrorLiveData.observe(viewLifecycleOwner) { error ->
+            error?.let {
+                showError("Oops", it)
+                previewViewModel.clearStreamerError() // Clear after showing to prevent re-show on rotation
+            }
         }
 
-        previewViewModel.endpointErrorLiveData.observe(viewLifecycleOwner) {
-            showError("Endpoint error", it)
+        previewViewModel.endpointErrorLiveData.observe(viewLifecycleOwner) { error ->
+            error?.let {
+                showError("Endpoint error", it)
+                previewViewModel.clearEndpointError() // Clear after showing to prevent re-show on rotation
+            }
         }
 
         // Lock/unlock orientation based on streaming state

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -182,11 +182,20 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
         return currentVideoSource != null && currentVideoSource !is ICameraSource
     }
 
-    // Streamer errors
-    private val _streamerErrorLiveData: MutableLiveData<String> = MutableLiveData()
-    val streamerErrorLiveData: LiveData<String> = _streamerErrorLiveData
-    private val _endpointErrorLiveData: MutableLiveData<String> = MutableLiveData()
-    val endpointErrorLiveData: LiveData<String> = _endpointErrorLiveData
+    // Streamer errors (nullable to support single-event pattern - cleared after observation)
+    private val _streamerErrorLiveData: MutableLiveData<String?> = MutableLiveData()
+    val streamerErrorLiveData: LiveData<String?> = _streamerErrorLiveData
+    private val _endpointErrorLiveData: MutableLiveData<String?> = MutableLiveData()
+    val endpointErrorLiveData: LiveData<String?> = _endpointErrorLiveData
+    
+    // Clear methods for single-event pattern (prevents re-showing errors on orientation change)
+    fun clearStreamerError() {
+        _streamerErrorLiveData.value = null
+    }
+    
+    fun clearEndpointError() {
+        _endpointErrorLiveData.value = null
+    }
 
     // RTMP status for UI display
     private val _rtmpStatusLiveData: MutableLiveData<String?> = MutableLiveData()


### PR DESCRIPTION
Changes Made:

Added clearStreamerError() method to clear the streamer error LiveData Added clearEndpointError() method to clear the endpoint error LiveData This implements the SingleLiveEvent pattern to prevent error dialogs from re-showing on orientation changes:

Error LiveData is nullable (String?)
Fragment observers check for null, show the error, then immediately clear it Clear methods set LiveData value back to null
On orientation change, the LiveData value is null, so observers don't trigger How it works:

Error occurs → ViewModel sets _streamerErrorLiveData.value = "error message" Fragment observer triggered → Shows error dialog → Calls clearStreamerError() ViewModel clears → Sets _streamerErrorLiveData.value = null User rotates device → Activity recreated → Observer re-triggered with null value → No dialog shown