### PR TITLE
The "Reconnection failed" message was briefly appearing after tapping "Stop" in notification

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -1339,6 +1339,14 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                         _reconnectionStatusLiveData.postValue(null)
                     }
                 } else {
+                    // Check if user stopped before showing failure message
+                    if (userStoppedManually) {
+                        Log.d(TAG, "User stopped during reconnection failure handling, skipping retry")
+                        isReconnecting = false
+                        _reconnectionStatusLiveData.value = null
+                        return@launch
+                    }
+                    
                     Log.w(TAG, "Reconnection attempt failed - will retry again in 5 seconds")
                     _reconnectionStatusLiveData.postValue("Reconnection failed - retrying in 5 seconds...")
                     
@@ -1351,6 +1359,14 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                     return@launch
                 }
             } catch (e: Exception) {
+                // Check if user stopped before showing failure message
+                if (userStoppedManually) {
+                    Log.d(TAG, "User stopped during reconnection exception handling, skipping retry")
+                    isReconnecting = false
+                    _reconnectionStatusLiveData.value = null
+                    return@launch
+                }
+                
                 Log.e(TAG, "Reconnection attempt threw exception: ${e.message}", e)
                 _reconnectionStatusLiveData.postValue("Reconnection failed - retrying in 5 seconds...")
                 


### PR DESCRIPTION
Root Cause:
When attemptReconnection() fails or throws an exception, it sets "Reconnection failed - retrying..." using postValue(). If you tap Stop right before or during this failure handling, the sequence was:

Reconnection attempt fails
Code executes: _reconnectionStatusLiveData.postValue("Reconnection failed...") - queued to main thread You tap Stop
Stop executes: _reconnectionStatusLiveData.value = null - executes immediately The queued "Reconnection failed" message arrives after and overwrites the null! Then it disappears when the check runs
Complete Fix:
Added userStoppedManually checks before setting failure messages in two places:

1. When reconnection attempt fails (line ~1340): } else {
    // Check if user stopped before showing failure message
    if (userStoppedManually) {
        Log.d(TAG, "User stopped during reconnection failure handling, skipping retry")
        isReconnecting = false
        _reconnectionStatusLiveData.value = null
        return@launch
    }

    Log.w(TAG, "Reconnection attempt failed - will retry again in 5 seconds")
    _reconnectionStatusLiveData.postValue("Reconnection failed - retrying in 5 seconds...")

2. When reconnection throws exception (line ~1359): } catch (e: Exception) {
    // Check if user stopped before showing failure message
    if (userStoppedManually) {
        Log.d(TAG, "User stopped during reconnection exception handling, skipping retry")
        isReconnecting = false
        _reconnectionStatusLiveData.value = null
        return@launch
    }

    Log.e(TAG, "Reconnection attempt threw exception: ${e.message}", e)
    _reconnectionStatusLiveData.postValue("Reconnection failed - retrying in 5 seconds...")

Now when you tap Stop during reconnection:

✅ All paths check userStoppedManually before showing failure messages ✅ No "Reconnection failed" message appears at all (not even briefly!) ✅ The status is cleared immediately and stays cleared Please test again - the "Reconnection failed" message should no longer appear at all when you tap Stop!