### PR TITLE
Attempt to fix settings crash potentially because of lifecycle sequence

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/settings/SettingsFragment.kt
@@ -163,10 +163,9 @@ class SettingsFragment : PreferenceFragmentCompat() {
             PreferencesDataStoreAdapter(requireContext().dataStore, lifecycleScope)
 
         setPreferencesFromResource(R.xml.root_preferences, rootKey)
-    }
-
-    override fun onResume() {
-        super.onResume()
+        
+        // Load preferences after XML is inflated to avoid timing issues
+        // where lazy properties are accessed before preferences are ready
         loadPreferences()
     }
     


### PR DESCRIPTION
The most likely culprit is lifecycle timing. Here's the sequence:

onCreate()
  ↓
onCreatePreferences() // XML inflation starts (async in some cases)
  ↓
onResume() // May fire before XML fully parsed
  ↓
loadPreferences() // Tries to access lazy properties
  ↓
Lazy property accessed → findPreference() called
  ↓
If XML not ready → returns null → !! crashes

Moved loadPreferences() from onResume() to onCreatePreferences()

Before:
```
override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
    preferenceManager.preferenceDataStore = PreferencesDataStoreAdapter(...)
    setPreferencesFromResource(R.xml.root_preferences, rootKey)
}

override fun onResume() {
    super.onResume()
    loadPreferences()  // ❌ Too early - preferences might not be ready
}
```

After:
```
override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
    preferenceManager.preferenceDataStore = PreferencesDataStoreAdapter(...)
    setPreferencesFromResource(R.xml.root_preferences, rootKey)

    // ✅ Load preferences immediately after XML inflation
    loadPreferences()
}

// onResume() override removed entirely
```

Why This Fixes the Issue:

- Correct Lifecycle Order: Preferences are now loaded immediately after setPreferencesFromResource() completes, ensuring the XML is fully inflated
- Eliminates Race Condition: No more gap between XML inflation and preference access
- Single Initialization: onCreatePreferences() is called once per fragment creation, avoiding redundant calls
- Combined with Previous Fixes: The defensive null checks are still in place as a safety net for corrupted data or missing keys