### PR TITLE
Rename endpoint key - users will have their endpoint reset to SRT endpoint by default

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -117,7 +117,7 @@
     <string name="endpoint">Endpoint</string>
 
     <string name="endpoint_type">Type</string>
-    <string name="endpoint_type_key">endpoint_type_key</string>
+    <string name="endpoint_type_key">endpoint_type_key_v2</string>
     <string name="to_ts_file">Write to a TS file</string>
     <string name="to_flv_file">Write to a FLV file</string>
     <string name="to_srt">Stream to a remote SRT device</string>


### PR DESCRIPTION
By changing the key from `endpoint_type_key` to `endpoint_type_key_v2`, existing users will have their endpoint reset to the SRT default (since the old key with the corrupted resource ID value won't be found), and the new stable integer IDs will be saved under the new key.