### PR TITLE
Attempt to fix: cannot start stream from notification after stream start and stop

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
@@ -391,6 +391,14 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
                     serviceScope.launch(Dispatchers.Default) {
                         try {
                             streamer?.stopStream()
+                            
+                            // Close the endpoint to allow fresh connection on next start
+                            try {
+                                streamer?.close()
+                                Log.i(TAG, "Endpoint closed after stop from notification")
+                            } catch (e: Exception) {
+                                Log.w(TAG, "Error closing endpoint after notification stop: ${e.message}", e)
+                            }
                         } catch (e: Exception) {
                             Log.w(TAG, "Stop from notification failed: ${e.message}")
                         }
@@ -427,6 +435,15 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
                             _userStoppedFromNotification.emit(Unit)
                             
                             streamer?.stopStream()
+                            
+                            // Close the endpoint to allow fresh connection on next start
+                            try {
+                                streamer?.close()
+                                Log.i(TAG, "Endpoint closed after stop from notification")
+                            } catch (e: Exception) {
+                                Log.w(TAG, "Error closing endpoint after notification stop: ${e.message}", e)
+                            }
+                            
                             // Refresh notification to show Start action on main thread
                             val notification = onCloseNotification() ?: onCreateNotification()
                             withContext(Dispatchers.Main) { customNotificationUtils.notify(notification) }


### PR DESCRIPTION
Summary: Fixed Notification Restart Issue
Problem Found:
When stopping the stream from the notification, the service only called stopStream() but never called close() on the endpoint. This left the endpoint connection open, causing the second start attempt from the notification to fail because open() was called on an already-open endpoint.

Root Cause:
The notification stop handlers in CameraStreamerService had two places that stopped the stream:

onStartCommand() ACTION_STOP_STREAM handler (line 388-398) notificationActionReceiver ACTION_STOP_STREAM handler (line 421-438) Both only called stopStream() without calling close(), leaving the endpoint open.

The Fix:
Added close() calls after stopStream() in both notification stop handlers to properly release the endpoint connection, allowing it to be reopened on the next start from notification.

Changes Made:

✅ Added streamer?.close() after stopStream() in onStartCommand ACTION_STOP_STREAM
✅ Added streamer?.close() after stopStream() in notificationActionReceiver ACTION_STOP_STREAM
✅ Added proper error logging for endpoint closure failures

This ensures that whether the user stops from the app or from the notification, the endpoint is properly closed and can be reopened for the next streaming session.