### PR TITLE
Try to fix "broken pipe -32" error

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
@@ -1068,7 +1068,10 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
             try {
                 // We're ready to start streaming
                 try { _serviceStreamStatus.tryEmit(StreamStatus.CONNECTING) } catch (_: Throwable) {}
-                currentStreamer.startStream()
+                // Protect startStream() from cancellation to prevent camera configuration errors
+                withContext(NonCancellable) {
+                    currentStreamer.startStream()
+                }
                 // Don't set STREAMING immediately - let getEffectiveServiceStatus() 
                 // derive it from isStreamingFlow.value to ensure accuracy
                 Log.i(TAG, "startStream() called successfully, waiting for isStreamingFlow to confirm")

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -346,7 +346,10 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                 }
             }
             
-            currentStreamer.startStream()
+            // Protect startStream() from cancellation to prevent camera configuration errors
+            withContext(NonCancellable) {
+                currentStreamer.startStream()
+            }
             Log.i(TAG, "startServiceStreaming: Stream started successfully")
             true
         } catch (e: TimeoutCancellationException) {


### PR DESCRIPTION


Now both open() and startStream() are protected from cancellation. This comprehensive fix addresses the "Broken pipe" error from both stack traces:

Complete Fix Summary:
Two Different Paths to Same Error:

First stack trace - Cancellation during endConfigure in the IPC layer
Second stack trace - Cancellation during createCaptureSession in the camera source
Root Cause:
Both happen when camera hardware configuration is interrupted by coroutine cancellation during the critical configuration phase.

The Fix:
Protected both critical camera operations with NonCancellable:

Applied in both locations:

✅ PreviewViewModel.startServiceStreaming() - UI starts
✅ CameraStreamerService.startStreamFromConfiguredEndpoint() - Notification starts
This ensures the camera configuration completes atomically even if the outer coroutine is cancelled, preventing "Broken pipe" errors from both code paths!

![1](https://media.discordapp.net/attachments/1416035702558425189/1430580993357647962/Screenshot_2025-10-22-17-36-13-797_com.miui.bugreport.jpg?ex=68fa4bdf&is=68f8fa5f&hm=7c3a4fa63c7bb872910de91ef32eb82a5f10b8ced71637996f1fa4a87d83d75d&=&format=webp&width=503&height=1118)

![4](https://media.discordapp.net/attachments/1416035702558425189/1430580994460876852/Screenshot_2025-10-22-17-35-44-712_com.miui.bugreport.jpg?ex=68fa4bdf&is=68f8fa5f&hm=e5b15858b90bee9263255e19a2d1fd9797c32cb68e415f13b216d2152825eb83&=&format=webp&width=503&height=1118)