### PR TITLE
Added automatic audio format conversion to MediaProjection audio source

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/rtmp/audio/AudioConverter.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/rtmp/audio/AudioConverter.kt
@@ -1,0 +1,171 @@
+package com.dimadesu.lifestreamer.rtmp.audio
+
+import android.media.AudioFormat
+import io.github.thibaultbee.streampack.core.logger.Logger
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import kotlin.math.roundToInt
+
+/**
+ * Audio format converter similar to Moblin's AVAudioConverter.
+ * Handles sample rate conversion and channel count conversion for PCM16 audio.
+ * 
+ * This is a simple linear interpolation resampler - not as sophisticated as
+ * iOS's AVAudioConverter, but sufficient for common conversions (44.1kHz -> 48kHz, mono -> stereo, etc.)
+ */
+class AudioConverter(
+    private val inputSampleRate: Int,
+    private val inputChannels: Int,
+    private val outputSampleRate: Int,
+    private val outputChannels: Int
+) {
+    companion object {
+        private const val TAG = "AudioConverter"
+    }
+
+    private val needsConversion = (inputSampleRate != outputSampleRate) || (inputChannels != outputChannels)
+    
+    init {
+        if (needsConversion) {
+            Logger.i(TAG, "Audio converter initialized: $inputSampleRate Hz $inputChannels ch -> $outputSampleRate Hz $outputChannels ch")
+        } else {
+            Logger.d(TAG, "Audio converter initialized but no conversion needed (formats match)")
+        }
+    }
+
+    /**
+     * Check if conversion is needed
+     */
+    fun isConversionNeeded(): Boolean = needsConversion
+
+    /**
+     * Calculate the output buffer size needed for a given input size
+     */
+    fun getOutputBufferSize(inputBufferSize: Int): Int {
+        if (!needsConversion) return inputBufferSize
+        
+        val inputFrames = inputBufferSize / (inputChannels * 2) // 2 bytes per sample (PCM16)
+        val outputFrames = (inputFrames.toDouble() * outputSampleRate / inputSampleRate).roundToInt()
+        return outputFrames * outputChannels * 2
+    }
+
+    /**
+     * Convert audio from input format to output format.
+     * Returns converted audio data or original data if no conversion needed.
+     */
+    fun convert(inputData: ByteArray): ByteArray {
+        if (!needsConversion) {
+            return inputData
+        }
+
+        // Convert byte array to PCM16 samples
+        val inputSamples = bytesToPcm16(inputData)
+        
+        // Step 1: Convert channels if needed
+        val channelConverted = if (inputChannels != outputChannels) {
+            convertChannels(inputSamples, inputChannels, outputChannels)
+        } else {
+            inputSamples
+        }
+        
+        // Step 2: Resample if needed
+        val resampled = if (inputSampleRate != outputSampleRate) {
+            resample(channelConverted, outputChannels, inputSampleRate, outputSampleRate)
+        } else {
+            channelConverted
+        }
+        
+        // Convert back to bytes
+        return pcm16ToBytes(resampled)
+    }
+
+    /**
+     * Convert byte array to array of PCM16 samples (Int16 values)
+     */
+    private fun bytesToPcm16(bytes: ByteArray): ShortArray {
+        val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+        val samples = ShortArray(bytes.size / 2)
+        for (i in samples.indices) {
+            samples[i] = buffer.short
+        }
+        return samples
+    }
+
+    /**
+     * Convert PCM16 samples back to byte array
+     */
+    private fun pcm16ToBytes(samples: ShortArray): ByteArray {
+        val buffer = ByteBuffer.allocate(samples.size * 2).order(ByteOrder.LITTLE_ENDIAN)
+        samples.forEach { buffer.putShort(it) }
+        return buffer.array()
+    }
+
+    /**
+     * Convert between different channel counts.
+     * Mono -> Stereo: Duplicate the channel
+     * Stereo -> Mono: Average the channels
+     */
+    private fun convertChannels(samples: ShortArray, fromChannels: Int, toChannels: Int): ShortArray {
+        if (fromChannels == toChannels) return samples
+        
+        return when {
+            fromChannels == 1 && toChannels == 2 -> {
+                // Mono to Stereo: duplicate each sample
+                ShortArray(samples.size * 2) { i ->
+                    samples[i / 2]
+                }
+            }
+            fromChannels == 2 && toChannels == 1 -> {
+                // Stereo to Mono: average each pair of samples
+                ShortArray(samples.size / 2) { i ->
+                    val left = samples[i * 2].toInt()
+                    val right = samples[i * 2 + 1].toInt()
+                    ((left + right) / 2).toShort()
+                }
+            }
+            else -> {
+                Logger.w(TAG, "Unsupported channel conversion: $fromChannels -> $toChannels")
+                samples
+            }
+        }
+    }
+
+    /**
+     * Resample audio using linear interpolation.
+     * This is a simple but effective method for common conversions like 44.1kHz -> 48kHz.
+     * 
+     * Note: samples array is interleaved (e.g., for stereo: [L, R, L, R, ...])
+     */
+    private fun resample(samples: ShortArray, channels: Int, fromRate: Int, toRate: Int): ShortArray {
+        if (fromRate == toRate) return samples
+        
+        val inputFrames = samples.size / channels
+        val outputFrames = (inputFrames.toDouble() * toRate / fromRate).roundToInt()
+        val outputSamples = ShortArray(outputFrames * channels)
+        
+        val ratio = inputFrames.toDouble() / outputFrames
+        
+        for (outFrame in 0 until outputFrames) {
+            val inFrameFloat = outFrame * ratio
+            val inFrame = inFrameFloat.toInt()
+            val fraction = inFrameFloat - inFrame
+            
+            // Linear interpolation between current and next frame
+            for (ch in 0 until channels) {
+                val sample1 = samples[inFrame * channels + ch].toInt()
+                
+                // If we're at the last frame, just use it without interpolation
+                val sample2 = if (inFrame + 1 < inputFrames) {
+                    samples[(inFrame + 1) * channels + ch].toInt()
+                } else {
+                    sample1
+                }
+                
+                val interpolated = sample1 + ((sample2 - sample1) * fraction).roundToInt()
+                outputSamples[outFrame * channels + ch] = interpolated.coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
+            }
+        }
+        
+        return outputSamples
+    }
+}

--- a/app/src/main/java/com/dimadesu/lifestreamer/rtmp/audio/MediaProjectionAudioSource.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/rtmp/audio/MediaProjectionAudioSource.kt
@@ -9,18 +9,115 @@ import android.media.projection.MediaProjection
 import android.os.Build
 import android.os.Process
 import androidx.annotation.RequiresApi
+import io.github.thibaultbee.streampack.core.elements.data.RawFrame
 import io.github.thibaultbee.streampack.core.elements.sources.audio.AudioSourceConfig
 import io.github.thibaultbee.streampack.core.elements.interfaces.Releasable
 import io.github.thibaultbee.streampack.core.elements.sources.audio.IAudioSourceInternal
+import io.github.thibaultbee.streampack.core.elements.utils.pool.IReadOnlyRawFrameFactory
+import io.github.thibaultbee.streampack.core.logger.Logger
+import io.github.thibaultbee.streampack.core.streamers.single.AudioConfig
 
 /**
  * App-local MediaProjection-based audio source that captures only app audio by UID filter.
- * This is a minimal implementation compatible with StreamPack's IAudioSourceInternal usage.
+ * Automatically detects and handles audio format conversion when RTMP stream format
+ * differs from encoder format (similar to Moblin's AVAudioConverter approach).
  */
 @RequiresApi(Build.VERSION_CODES.Q)
 class MediaProjectionAudioSource(
     private val mediaProjection: MediaProjection
 ) : AudioRecordSource(), Releasable {
+
+    companion object {
+        private const val TAG = "MediaProjectionAudioSource"
+    }
+
+    private var audioConverter: AudioConverter? = null
+    private var conversionCounter = 0L
+
+    override suspend fun configure(config: AudioSourceConfig) {
+        // Let parent configure the AudioRecord
+        super.configure(config)
+        
+        // Check if we need format conversion by inspecting the actual AudioRecord format
+        // vs the requested encoder format
+        val audioRecord = getAudioRecordForInspection()
+        if (audioRecord != null) {
+            val captureRate = audioRecord.sampleRate
+            val captureChannels = audioRecord.channelCount
+            val encoderRate = config.sampleRate
+            val encoderChannels = AudioConfig.getNumberOfChannels(config.channelConfig)
+            
+            if (captureRate != encoderRate || captureChannels != encoderChannels) {
+                Logger.i(TAG, "Format mismatch detected - creating audio converter")
+                Logger.i(TAG, "  Capture: $captureRate Hz, $captureChannels ch")
+                Logger.i(TAG, "  Encoder: $encoderRate Hz, $encoderChannels ch")
+                
+                audioConverter = AudioConverter(
+                    inputSampleRate = captureRate,
+                    inputChannels = captureChannels,
+                    outputSampleRate = encoderRate,
+                    outputChannels = encoderChannels
+                )
+            } else {
+                Logger.d(TAG, "Capture and encoder formats match ($captureRate Hz, $captureChannels ch) - no conversion needed")
+                audioConverter = null
+            }
+        }
+    }
+
+    override fun fillAudioFrame(frame: RawFrame): RawFrame {
+        // Get the original audio frame from parent
+        val originalFrame = super.fillAudioFrame(frame)
+        
+        // If no conversion needed, just return it
+        val converter = audioConverter ?: return originalFrame
+        
+        try {
+            // Extract audio data from the frame buffer
+            val buffer = originalFrame.rawBuffer
+            buffer.rewind()
+            val inputData = ByteArray(buffer.remaining())
+            buffer.get(inputData)
+            
+            // Convert the audio
+            val outputData = converter.convert(inputData)
+            
+            // Put converted data back into the frame
+            buffer.clear()
+            buffer.put(outputData)
+            buffer.flip()
+            
+            conversionCounter++
+            if (conversionCounter % 500 == 0L) {
+                Logger.d(TAG, "Converted audio frame #$conversionCounter (${inputData.size} bytes -> ${outputData.size} bytes)")
+            }
+            
+            return originalFrame
+        } catch (e: Exception) {
+            Logger.e(TAG, "Error converting audio frame: ${e.message}")
+            throw e
+        }
+    }
+
+    override fun getAudioFrame(frameFactory: IReadOnlyRawFrameFactory): RawFrame {
+        val converter = audioConverter
+        if (converter == null) {
+            // No conversion needed, use parent implementation
+            return super.getAudioFrame(frameFactory)
+        }
+        
+        // Calculate the buffer size needed for output format
+        val inputBufferSize = getBufferSizeForInspection() ?: 0
+        val outputBufferSize = if (inputBufferSize > 0) {
+            converter.getOutputBufferSize(inputBufferSize)
+        } else {
+            inputBufferSize
+        }
+        
+        // Create frame with output buffer size
+        val frame = frameFactory.create(outputBufferSize, 0)
+        return fillAudioFrame(frame)
+    }
 
     // let AudioRecordSource.configure handle buffer sizing and processor setup
     override fun buildAudioRecord(config: AudioSourceConfig, bufferSize: Int): AudioRecord {
@@ -41,7 +138,29 @@ class MediaProjectionAudioSource(
             .build()
     }
 
-    // Behavior (configure/start/stop/fill/get) is provided by AudioRecordSource.
+    // Helper to access AudioRecord for inspection (uses reflection to access private field)
+    private fun getAudioRecordForInspection(): AudioRecord? {
+        return try {
+            val field = AudioRecordSource::class.java.getDeclaredField("audioRecord")
+            field.isAccessible = true
+            field.get(this) as? AudioRecord
+        } catch (e: Exception) {
+            Logger.w(TAG, "Could not access AudioRecord for inspection: ${e.message}")
+            null
+        }
+    }
+
+    private fun getBufferSizeForInspection(): Int? {
+        return try {
+            val field = AudioRecordSource::class.java.getDeclaredField("bufferSize")
+            field.isAccessible = true
+            field.get(this) as? Int
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    // Behavior (configure/start/stop) is provided by AudioRecordSource.
 }
 
 @RequiresApi(Build.VERSION_CODES.Q)


### PR DESCRIPTION
What's New:
1. AudioConverter.kt - A PCM audio format converter that handles:

✅ Sample rate conversion (e.g., 44.1kHz → 48kHz) using linear interpolation ✅ Channel conversion (mono ↔ stereo)
✅ Automatic detection of whether conversion is needed
2. Enhanced MediaProjectionAudioSource:

✅ Auto-detects format mismatches between captured RTMP audio and encoder settings ✅ Converts on-the-fly if formats don't match
✅ Zero overhead if formats already match (no conversion) ✅ Detailed logging to see what's happening
How It Works:
When you start RTMP re-streaming, MediaProjection captures the RTMP audio at whatever format it's playing (e.g., 48kHz mono) Your encoder might want a different format (e.g., 48kHz stereo) The converter automatically detects this and converts every audio frame in real-time You'll see logs like:
Benefits Over ExoPlayer Approach:
✅ Uses your proven MediaProjection capture (no stuttering) ✅ Adds only the format conversion piece from Moblin ✅ No complex threading or timing issues
✅ Works exactly like before if formats already match Test it with your RTMP streams and let me know if the audio quality is good!