### PR TITLE
Apply more widely compatible way to config Gradle - fixes building from Android Studio

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,11 +30,10 @@ android {
         }
     }
     
-    androidComponents {
-        onVariants { variant ->
-            variant.outputs.forEach { output ->
-                output.outputFileName.set("LifeStreamer-${variant.name}.apk")
-            }
+    applicationVariants.all {
+        outputs.all {
+            (this as com.android.build.gradle.internal.api.BaseVariantOutputImpl).outputFileName =
+                "LifeStreamer-${name}.apk"
         }
     }
     compileOptions {


### PR DESCRIPTION
I've reverted to the applicationVariants.all approach which is more widely compatible. This will generate APK names like LifeStreamer-release.apk and LifeStreamer-debug.apk.