### PR TITLE
When RTMP source audio is not available use Media Projection if it was allowed - will generate silence instead of using device mic. If not allowed - use mic

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -1667,9 +1667,13 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                 // Cancel existing retry job if any
                 rtmpRetryJob?.cancel()
                 
-                // Fallback to bitmap immediately - this will properly release the RTMPVideoSource
-                // and set microphone audio
-                RtmpSourceSwitchHelper.switchToBitmapFallback(currentStreamer, testBitmap)
+                // Fallback to bitmap immediately - will use MediaProjection if available, otherwise mic
+                RtmpSourceSwitchHelper.switchToBitmapFallback(
+                    currentStreamer, 
+                    testBitmap,
+                    streamingMediaProjection,
+                    mediaProjectionHelper
+                )
                 
                 // Small delay to let the video source release complete and surface processor cleanup
                 delay(100)


### PR DESCRIPTION
This should make audio switching less glitchy when RTMP source disconnects and some other flows.