### PR TITLE
Sometimes it was trying to create new Media Projection when there was already one created

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/RtmpSourceSwitchHelper.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/RtmpSourceSwitchHelper.kt
@@ -231,18 +231,25 @@ internal object RtmpSourceSwitchHelper {
                             // Set audio source: prefer MediaProjection if streaming, otherwise microphone
                             val isStreaming = currentStreamer.isStreamingFlow.value == true
                             val projection = streamingMediaProjection ?: mediaProjectionHelper.getMediaProjection()
+                            val currentAudioSource = currentStreamer.audioInput?.sourceFlow?.value
+                            val currentAudioIsMediaProjection = currentAudioSource?.javaClass?.simpleName?.contains("MediaProjection") == true
                             
                             if (isStreaming && projection != null && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
                                 // Use MediaProjection audio when streaming
-                                try {
-                                    currentStreamer.setAudioSource(MediaProjectionAudioSourceFactory(projection))
-                                    Log.i(TAG, "Set MediaProjection audio for RTMP")
-                                } catch (ae: Exception) {
-                                    Log.w(TAG, "MediaProjection audio failed, using microphone: ${ae.message}")
+                                // But check if we already have MediaProjection audio to avoid "audio policy" error
+                                if (currentAudioIsMediaProjection) {
+                                    Log.i(TAG, "MediaProjection audio already set, keeping it for RTMP")
+                                } else {
                                     try {
-                                        currentStreamer.setAudioSource(MicrophoneSourceFactory())
-                                    } catch (micEx: Exception) {
-                                        Log.w(TAG, "Microphone fallback failed: ${micEx.message}")
+                                        currentStreamer.setAudioSource(MediaProjectionAudioSourceFactory(projection))
+                                        Log.i(TAG, "Set MediaProjection audio for RTMP")
+                                    } catch (ae: Exception) {
+                                        Log.w(TAG, "MediaProjection audio failed, using microphone: ${ae.message}")
+                                        try {
+                                            currentStreamer.setAudioSource(MicrophoneSourceFactory())
+                                        } catch (micEx: Exception) {
+                                            Log.w(TAG, "Microphone fallback failed: ${micEx.message}")
+                                        }
                                     }
                                 }
                             } else {


### PR DESCRIPTION
The Problem:
When you were already streaming with MediaProjection audio (e.g., streaming SRT with camera using MediaProjection permission), and then switched video source to RTMP, the code tried to create a NEW MediaProjection audio source without checking if one was already active. Android only allows one MediaProjection audio capture at a time, so creating a second one fails with "could not register audio policy".

The Solution:
Before trying to set MediaProjection audio for RTMP, now checks if the current audio source is already MediaProjection:

If already using MediaProjection: Keep it (no need to recreate) If not using MediaProjection: Create new MediaProjection audio source If MediaProjection fails: Fall back to microphone
This prevents the "audio policy" error when switching between video sources (camera → RTMP, RTMP → bitmap, etc.) while already streaming with MediaProjection audio.