### PR TITLE
Fix on start from notification it doesn't try to reconnect when stream is interrupted

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
@@ -124,8 +124,8 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
     // Cache last notification state to avoid re-posting identical notifications
     private var lastNotificationKey: String? = null
     // Critical error flow for the UI to show dialogs (non-transient errors)
-    // Use a replay of 0 so only fresh errors are observed by listeners
-    private val _criticalErrors = kotlinx.coroutines.flow.MutableSharedFlow<String>(replay = 0)
+    // Use replay=1 to cache the last error for late subscribers (e.g., when starting from notification before UI is bound)
+    private val _criticalErrors = kotlinx.coroutines.flow.MutableSharedFlow<String>(replay = 1, extraBufferCapacity = 0)
     val criticalErrors = _criticalErrors.asSharedFlow()
     // Current outgoing video bitrate in bits per second (nullable when unknown)
     private val _currentBitrateFlow = MutableStateFlow<Int?>(null)


### PR DESCRIPTION
The ViewModel does observe criticalErrors and triggers reconnection. But there's a critical issue - this observer is set up after service is ready at line 907:

The Problem: When you start from notification:

Notification action calls startStreamFromConfiguredEndpoint() If it fails, it emits to _criticalErrors
But the ViewModel might not be bound yet, so there's no observer collecting the errors! The critical errors are emitted but lost because no one is listening.

The service binding happens in init {} (I saw it earlier around line 544), so it should be bound when the ViewModel is created. But the critical error observer waits for _serviceReady which is set in onServiceConnected.

The race condition:

User taps notification Start button
Notification receiver calls startStreamFromConfiguredEndpoint() It fails and emits to _criticalErrors
But if the ViewModel isn't created yet or service isn't connected yet, no one is listening! Solution: Use replay=1 for _criticalErrors so the last error is cached and delivered to late subscribers.

Changed replay = 0 to replay = 1 and added extraBufferCapacity = 0 to keep the same buffer behavior. Now when notification starts fail before the ViewModel is ready to observe, the error will be cached and delivered when the observer subscribes.

This should fix the notification retry issue - errors emitted during early notification starts will now be preserved for the ViewModel to pick up once it's ready.