### PR TITLE
Fix notification buttons don't work on Samsung S23

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
@@ -389,9 +389,7 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
                             
                             // Close the endpoint to allow fresh connection on next start
                             try {
-                                withTimeout(5000) {
-                                    streamer?.close()
-                                }
+                                streamer?.close()
                                 Log.i(TAG, "Endpoint closed after stop from notification")
                             } catch (e: Exception) {
                                 Log.w(TAG, "Error closing endpoint after notification stop: ${e.message}", e)


### PR DESCRIPTION
Samsung's aggressive battery optimization blocks dynamic broadcast receivers.

Here's why:

The Problem:

- Android allows two types of broadcast receivers:
  - Manifest-declared (static) - registered in AndroidManifest.xml, always work
  - Runtime-registered (dynamic) - registered with registerReceiver(), can be killed

What Samsung Does:

- Samsung's "Optimize battery usage" feature aggressively kills runtime-registered receivers for background services
- This is part of their battery saving strategy on devices like S23
- Even though your service is foreground, Samsung's power manager can still block the broadcasts from being delivered to dynamic receivers

What You Were Using:
```
// This creates a BROADCAST PendingIntent
PendingIntent.getBroadcast(...)  // ❌ Relies on BroadcastReceiver

// And you registered it dynamically (not in manifest)
registerReceiver(notificationActionReceiver, filter)  // ❌ Can be blocked
```

The Fix:
```
// This creates a SERVICE PendingIntent
PendingIntent.getService(...)  // ✅ Directly calls service

// No receiver needed - goes straight to onStartCommand()
override fun onStartCommand(intent: Intent?, ...) {  // ✅ Cannot be blocked
    when (intent?.action) {
        ACTION_START_STREAM -> ...
    }
}
```

Why Service Intents Work:

- They call onStartCommand() directly on your running service
- No middleman receiver that can be blocked
- Samsung can't block intents to foreground services without breaking the entire notification system
- This is the recommended approach for notification actions on services (per Android docs)

The Evidence:

- Works on Pixel (stock Android with lenient power management)
- Fails on Samsung (aggressive power management)
- Classic symptom of broadcast receiver blocking

This is a well-known Samsung issue - many developers hit this with notification buttons on Samsung devices.