### PR TITLE
Fix parts of settings screen UI go under phone buttons and camera on Samsung S23

### DIFF
--- a/app/src/main/res/layout/settings_activity.xml
+++ b/app/src/main/res/layout/settings_activity.xml
@@ -1,6 +1,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
 
     <FrameLayout
         android:id="@+id/settings"


### PR DESCRIPTION
I've added android:fitsSystemWindows="true" to the Settings activity layout. This will ensure that the settings content adjusts to avoid being covered by system UI elements like the navigation bar on Samsung S23 and other devices.