### PR TITLE
Make UVC TEST screen UI fit within screen and not go under phone camera, notch, etc.

### DIFF
--- a/app/src/main/res/layout/activity_uvc_test.xml
+++ b/app/src/main/res/layout/activity_uvc_test.xml
@@ -5,6 +5,7 @@
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:background="@android:color/black"
+  android:fitsSystemWindows="true"
   android:orientation="vertical">
 
   <com.google.android.material.appbar.AppBarLayout


### PR DESCRIPTION
Added android:fitsSystemWindows="true" to the root LinearLayout in the UVC test activity layout.

This will make the UI properly fit within the screen and avoid going under the phone camera, notch, or other system UI elements, just like it does in the settings activity.