### PR TITLE
Lock/unlock UI orientation properly on start/stop from notification similar to start/stop from main UI + fix for wrong start/stop button state

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
@@ -489,6 +489,9 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
                             
                             streamer?.stopStream()
                             
+                            // Unlock stream rotation since streaming has stopped
+                            unlockStreamRotation()
+                            
                             // Close the endpoint to allow fresh connection on next start
                             try {
                                 withTimeout(3000) {

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -657,8 +657,14 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
                     }
                 }
             } else {
-                Log.d(TAG, "App returned to foreground - not streaming, orientation remains unlocked")
-                // Not streaming, start preview immediately
+                Log.d(TAG, "App returned to foreground - not streaming, ensuring orientation unlocked")
+                // Not streaming - ensure orientation is unlocked
+                // This handles the case where stream was stopped from notification while app was in background
+                if (rememberedLockedOrientation != null) {
+                    unlockOrientation()
+                    Log.d(TAG, "Unlocked orientation that was locked from previous streaming session")
+                }
+                // Start preview immediately
                 try {
                     inflateStreamerPreview()
                 } catch (e: Exception) {


### PR DESCRIPTION
Orientation Lock/Unlock Analysis ✅

LOCKING (All Covered)
Location	When	Type
PreviewFragment - isStreamingLiveData observer	Stream starts from UI	UI + Stream
PreviewFragment - streamStatus.collect STARTING	Status becomes STARTING	UI + Stream
PreviewFragment - streamStatus.collect CONNECTING	Status becomes CONNECTING	UI + Stream
PreviewFragment - streamStatus.collect STREAMING	Safety check	UI + Stream
PreviewFragment - onStart()	Lifecycle restore from Service	UI only
PreviewFragment - onResume()	Lifecycle restore from Service	UI only
PreviewViewModel - startStream() (line 1347)	Before starting stream	Stream only
CameraStreamerService - startStreamFromConfiguredEndpoint() (line 1038)	Start from notification	Stream only
UNLOCKING (All Covered)
Location	When	Type
PreviewFragment - isStreamingLiveData observer	Stream stops (not reconnecting)	UI only
PreviewFragment - streamStatus.collect NOT_STREAMING/ERROR	Status becomes stopped	UI only
PreviewFragment - onResume()	Returning from background when not streaming	UI only
PreviewViewModel - reconnection cancel (line 1606)	User cancels reconnection	Stream only
PreviewViewModel - connection cancel (line 1670)	User cancels connection attempt	Stream only
PreviewViewModel - stream stop (line 1806)	Normal stream stop	Stream only
CameraStreamerService - ACTION_STOP_STREAM (line 493)	Stop from notification	Stream only

Summary
All scenarios are covered:

✅ Start from UI → Locks both UI and stream rotation
✅ Start from notification → Locks stream rotation (Service), UI locks when Fragment resumes
✅ Stop from UI → Unlocks both UI and stream rotation
✅ Stop from notification → Unlocks stream rotation (Service), UI unlocks in onResume() or observer
✅ Lifecycle restore (onStart/onResume) → Restores UI lock from Service if streaming
✅ Returning from background (not streaming) → Explicit unlock in onResume() if was previously locked
The two-layer approach (UI orientation + stream rotation) ensures:

UI stays locked to prevent jarring rotation during streaming
Stream rotation stays locked to ensure consistent encoding/reconnection
Both unlock properly regardless of whether stopped from UI or notification