### PR TITLE
Fix noisy audio when turning off Bluetooth toggle

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/audio/ConditionalAudioSourceFactory.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/audio/ConditionalAudioSourceFactory.kt
@@ -8,20 +8,25 @@ import io.github.thibaultbee.streampack.core.elements.sources.audio.audiorecord.
 /**
  * Audio source factory that handles mic-based audio with USB awareness.
  * 
- * @param forceUnprocessed When true, forces UNPROCESSED audio source regardless of USB detection.
- *                         Use this when switching to USB video to force audio reinitialization.
+ * @param forceUnprocessed When true, forces UNPROCESSED audio source regardless of USB detection
+ *                         AND forces recreation (isSourceEquals returns false).
  *                         When false (default), auto-detects USB audio and chooses appropriately.
+ * @param forceDefault When true, forces DEFAULT audio source (with AEC/NS effects) regardless of
+ *                     USB detection AND forces recreation. Used when transitioning back from
+ *                     UNPROCESSED to DEFAULT after BT toggle off.
  * 
  * Sources used:
- * - forceUnprocessed=true → MicrophoneSource(unprocessed=true) with no effects
- * - forceUnprocessed=false + USB detected → MicrophoneSource(unprocessed=true) with no effects
- * - forceUnprocessed=false + no USB → MicrophoneSource(unprocessed=false) with AEC+NS effects
+ * - forceUnprocessed=true → MicrophoneSource(unprocessed=true) with no effects, forces recreation
+ * - forceDefault=true → MicrophoneSource(unprocessed=false) with AEC+NS effects, forces recreation
+ * - neither forced + USB detected → MicrophoneSource(unprocessed=true) with no effects
+ * - neither forced + no USB → MicrophoneSource(unprocessed=false) with AEC+NS effects
  * 
  * SCO/Bluetooth is negotiated asynchronously by the service and will call
  * `setAudioSource(...)` to switch to BluetoothAudioSource only after SCO is confirmed.
  */
 class ConditionalAudioSourceFactory(
-    private val forceUnprocessed: Boolean = false
+    private val forceUnprocessed: Boolean = false,
+    private val forceDefault: Boolean = false
 ) : IAudioSourceInternal.Factory {
     
     companion object {
@@ -29,8 +34,12 @@ class ConditionalAudioSourceFactory(
     }
 
     override suspend fun create(context: Context): IAudioSourceInternal {
-        val useUnprocessed = forceUnprocessed || UsbAudioManager.hasUsbAudioInput(context)
-        Log.i(TAG, "Creating microphone source (unprocessed=$useUnprocessed, forced=$forceUnprocessed)")
+        val useUnprocessed = when {
+            forceDefault -> false  // Force DEFAULT (processed) with effects
+            forceUnprocessed -> true  // Force UNPROCESSED
+            else -> UsbAudioManager.hasUsbAudioInput(context)  // Auto-detect
+        }
+        Log.i(TAG, "Creating microphone source (unprocessed=$useUnprocessed, forceUnprocessed=$forceUnprocessed, forceDefault=$forceDefault)")
         return MicrophoneSourceFactory(unprocessed = useUnprocessed).create(context)
     }
 
@@ -39,7 +48,7 @@ class ConditionalAudioSourceFactory(
         if (source == null) return false
         
         // When forced, always recreate to get fresh AudioRecord
-        if (forceUnprocessed) return false
+        if (forceUnprocessed || forceDefault) return false
         
         // If source is already a microphone/AudioRecord source, no need to recreate
         // This allows BT switching to work since BT sources won't match
@@ -49,6 +58,6 @@ class ConditionalAudioSourceFactory(
     }
     
     override fun toString(): String {
-        return "ConditionalAudioSourceFactory(forceUnprocessed=$forceUnprocessed)"
+        return "ConditionalAudioSourceFactory(forceUnprocessed=$forceUnprocessed, forceDefault=$forceDefault)"
     }
 }


### PR DESCRIPTION
When disabling Bluetooth audio during streaming, Samsung's audio processing would get into a bad state causing persistent noise. The AEC/NS effects interacted badly with the SCO→normal routing transition.

Fix: Use a 3-step approach when disabling BT:
1. Switch to UNPROCESSED (no effects) while still on SCO
2. Stop SCO and reset audio mode to NORMAL
3. Switch to DEFAULT with AEC/NS effects (if no USB connected)

This releases audio effects cleanly before the routing change, preventing the corrupted state.

- Add forceDefault parameter to ConditionalAudioSourceFactory
- Skip step 3 when USB audio is connected (stays UNPROCESSED)