### PR TITLE
Fix "Surface was abandoned" on Settings to Main screen transition. It could also prevent app from publishing stream afterwards and required app restart to fix

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -621,6 +621,7 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
 
     override fun onPause() {
         super.onPause()
+        previewViewModel.onUiPaused()
         // DO NOT stop streaming when going to background - the service should continue streaming
         // DO NOT stop preview either when the camera is being used for streaming -
         // the camera source is shared between preview and streaming, so stopping preview
@@ -635,6 +636,7 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
 
     override fun onResume() {
         super.onResume()
+        previewViewModel.onUiResumed()
         Log.d(TAG, "onResume() - app returning to foreground, preview should already be active")
         
         // Request permissions in onResume() instead of onStart() to fix preview freeze


### PR DESCRIPTION
## The Issue

**Problem:** On fresh install from Google Play Store, when users opened Settings and returned to the main screen, they got a "Surface was abandoned" error that prevented streaming until app restart.

**Root Cause:** A race condition between two concurrent operations:

1. **Going to Settings** triggers `onPause()` → `PreviewView.stopPreview()` → invalidates camera surfaces
2. **DataStore access** in Settings causes `videoConfigFlow` to emit → `setVideoConfig()` tries to restart the camera session

These happen nearly simultaneously (~12ms apart in logs). When `setVideoConfig()` tries to create a new camera capture session while `stopPreview()` is releasing surfaces, the camera system throws "Surface was abandoned".

## The Fix

**Solution:** Defer config changes when the UI is in background.

1. Track UI foreground state with `isUiInForeground` flag
2. When `videoConfigFlow`/`audioConfigFlow` emit while UI is paused → save to `pendingVideoConfig`/`pendingAudioConfig` instead of applying immediately
3. When `onResume()` is called → wait for service to be ready, then apply any pending configs

This ensures `setVideoConfig()` never runs while the PreviewView is stopping/invalidating surfaces.

**Key code changes:**
- PreviewViewModel.kt: Added deferred config mechanism
- PreviewFragment.kt: Added `onUiPaused()`/`onUiResumed()` calls in lifecycle methods

---

The key is **DataStore initialization timing**:

**On fresh install / after data wipe:**
1. App starts → DataStore file **doesn't exist yet**
2. `videoConfigFlow` starts collecting → gets initial default values (first emission)
3. `setVideoConfig()` applies defaults → OK (UI is in foreground)
4. User opens Settings → `onPause()` called
5. Settings screen **accesses DataStore for the first time** → this **creates/initializes the preferences file**
6. This initialization triggers `videoConfigFlow` to **emit again** (even if values are the same defaults)
7. `setVideoConfig()` runs while `stopPreview()` is happening → **CRASH**

**On subsequent launches:**
1. App starts → DataStore file **already exists** with saved values
2. `videoConfigFlow` emits initial values → `setVideoConfig()` called → OK
3. User opens Settings → `onPause()` called
4. Settings screen reads from DataStore → **file already exists, no change, no emission**
5. Flow uses `distinctUntilChanged()` → same values = no new emission
6. **No crash** because `setVideoConfig()` doesn't run again

**TL;DR:** The bug only triggers when DataStore is being initialized/written for the first time, which happens on fresh install when you first visit Settings. After that, the preferences file exists and reading it doesn't cause new emissions.