### PR TITLE
[WORK IN PROGRESS] [Experiment] Inject blurred frozen frame during camera switching

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
@@ -19,8 +19,10 @@ import android.os.PowerManager
 import android.util.Log
 import com.dimadesu.lifestreamer.R
 import io.github.thibaultbee.streampack.core.streamers.single.ISingleStreamer
+import io.github.thibaultbee.streampack.core.streamers.single.SingleStreamer
 import io.github.thibaultbee.streampack.services.StreamerService
-import io.github.thibaultbee.streampack.services.utils.SingleStreamerFactory
+import io.github.thibaultbee.streampack.services.utils.StreamerFactory
+import io.github.thibaultbee.streampack.core.elements.processing.video.DefaultSurfaceProcessorFactory
 import android.content.pm.ServiceInfo
 import android.os.Build
 import android.view.Surface
@@ -56,11 +58,15 @@ import com.dimadesu.lifestreamer.audio.ScoOrchestrator
  * CameraStreamerService extending StreamerService for camera streaming
  */
 class CameraStreamerService : StreamerService<ISingleStreamer>(
-    streamerFactory = SingleStreamerFactory(
-        withAudio = true, 
-        withVideo = true 
-        // Remove defaultRotation - let StreamPack detect it automatically and we'll update it dynamically
-    ),
+    streamerFactory = object : StreamerFactory<ISingleStreamer> {
+        override fun create(context: Context): ISingleStreamer =
+            SingleStreamer(
+                context,
+                withAudio = true,
+                withVideo = true,
+                surfaceProcessorFactory = surfaceProcessorFactory
+            )
+    },
     notificationId = 1001,
     channelId = "camera_streaming_channel", 
     channelNameResourceId = R.string.streaming_channel_name,
@@ -73,6 +79,13 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
         const val ACTION_START_STREAM = "com.dimadesu.lifestreamer.action.START_STREAM"
         const val ACTION_TOGGLE_MUTE = "com.dimadesu.lifestreamer.action.TOGGLE_MUTE"
         const val ACTION_EXIT_APP = "com.dimadesu.lifestreamer.action.EXIT_APP"
+
+        /**
+         * Persistent GL surface processor factory. Held here so the ViewModel can
+         * call [DefaultSurfaceProcessorFactory.setAlpha] for fade-in/fade-out during
+         * camera transitions without going through the StreamPack pipeline internals.
+         */
+        val surfaceProcessorFactory = DefaultSurfaceProcessorFactory()
         const val ACTION_OPEN_FROM_NOTIFICATION = "com.dimadesu.lifestreamer.ACTION_OPEN_FROM_NOTIFICATION"
 
         /**

--- a/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
@@ -82,7 +82,7 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
 
         /**
          * Persistent GL surface processor factory. Held here so the ViewModel can
-         * call [DefaultSurfaceProcessorFactory.setAlpha] for fade-in/fade-out during
+         * call [DefaultSurfaceProcessorFactory.setBrightness] to go black during
          * camera transitions without going through the StreamPack pipeline internals.
          */
         val surfaceProcessorFactory = DefaultSurfaceProcessorFactory()

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -364,7 +364,7 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
                         setOnClickListener {
                             lifecycleScope.launch {
                                 try {
-                                    (previewViewModel.streamer as? IWithVideoSource)?.setCameraId(camera.id)
+                                    previewViewModel.switchCameraWithTransition(camera.id)
                                     Log.i(TAG, "Switched to camera: ${camera.displayName}")
                                     
                                     // Update button states
@@ -881,7 +881,7 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
                 val selectedId = cameraIds[which]
                 lifecycleScope.launch {
                     try {
-                        (previewViewModel.streamer as? IWithVideoSource)?.setCameraId(selectedId)
+                        previewViewModel.switchCameraWithTransition(selectedId)
                         // Update button text to show chosen camera and orientation
                         binding.switchSourceButton.contentDescription = items[which]
                     } catch (t: Throwable) {

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -55,7 +55,6 @@ import io.github.thibaultbee.streampack.core.elements.sources.IMediaProjectionSo
 import com.dimadesu.lifestreamer.utils.ObservableViewModel
 import com.dimadesu.lifestreamer.utils.dataStore
 import com.dimadesu.lifestreamer.utils.isEmpty
-import com.dimadesu.lifestreamer.utils.blurForTransition
 import com.dimadesu.lifestreamer.utils.setNextCameraId
 import io.github.thibaultbee.streampack.core.interfaces.setCameraId
 import com.dimadesu.lifestreamer.utils.toggleBackToFront
@@ -2504,9 +2503,10 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
     }
 
     /**
-     * Switch to a specific camera by ID, injecting a blurred frozen frame during the
+     * Switch to a specific camera by ID, injecting a black frame during the
      * transition so the encoder stays fed and OBS / SRT receivers see no gap.
-     * Falls back to a plain delay if snapshot fails or not currently streaming.
+     * The black frame is held long enough for the old camera to fully tear down
+     * and the new camera's 3A (auto-exposure, AWB) to converge.
      */
     @RequiresPermission(Manifest.permission.CAMERA)
     fun switchCameraWithTransition(cameraId: String) {
@@ -2521,21 +2521,24 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
             videoSourceMutex.withLock {
                 try {
                     if (currentStreamer.isStreamingFlow.value == true) {
-                        val frozenBlurred = try {
-                            currentStreamer.videoInput?.takeSnapshot(0)?.blurForTransition()
+                        // Snapshot only to get current frame dimensions;
+                        // fall back to 1920×1080 if it fails.
+                        val snapshot = try {
+                            currentStreamer.videoInput?.takeSnapshot(0)
                         } catch (e: Exception) {
-                            Log.w(TAG, "Could not take snapshot for transition, falling back to plain delay", e)
+                            Log.w(TAG, "Could not take snapshot for transition frame size", e)
                             null
                         }
-                        if (frozenBlurred != null) {
-                            currentStreamer.setVideoSource(BitmapSourceFactory(frozenBlurred))
-                            // 400ms: camera2 session teardown is async and takes ~180-300ms.
-                            // This gives the old camera time to fully release while the
-                            // blurred frozen frame keeps the encoder fed throughout.
-                            delay(400)
-                        } else {
-                            delay(400)
-                        }
+                        val blackFrame = Bitmap.createBitmap(
+                            snapshot?.width ?: 1920,
+                            snapshot?.height ?: 1080,
+                            Bitmap.Config.ARGB_8888
+                        )
+                        snapshot?.recycle()
+                        currentStreamer.setVideoSource(BitmapSourceFactory(blackFrame))
+                        // 3s: covers camera2 teardown (~300ms) + new camera open +
+                        // 3A convergence (~1-1.5s) with margin to avoid any artifacts.
+                        delay(3000)
                     } else {
                         delay(300)
                     }
@@ -2576,25 +2579,23 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                 videoSourceMutex.withLock {
                     try {
                         if (currentStreamer.isStreamingFlow.value == true) {
-                            // While streaming: inject a blurred frozen frame so the encoder
-                            // keeps producing output during the camera switch gap.  OBS / the
-                            // SRT receiver always has frames to decode and shows a deliberate
-                            // visual transition instead of a glitch or dropout.
-                            val frozenBlurred = try {
-                                currentStreamer.videoInput?.takeSnapshot(0)?.blurForTransition()
+                            // While streaming: inject a black frame so the encoder
+                            // keeps producing output during the camera switch gap.
+                            val snapshot = try {
+                                currentStreamer.videoInput?.takeSnapshot(0)
                             } catch (e: Exception) {
-                                Log.w(TAG, "Could not take snapshot for transition, falling back to plain delay", e)
+                                Log.w(TAG, "Could not take snapshot for transition frame size", e)
                                 null
                             }
-                            if (frozenBlurred != null) {
-                                currentStreamer.setVideoSource(BitmapSourceFactory(frozenBlurred))
-                                // 400ms: camera2 session teardown is async and takes ~180-300ms.
-                                // This gives the old camera time to fully release while the
-                                // blurred frozen frame keeps the encoder fed throughout.
-                                delay(400)
-                            } else {
-                                delay(400)
-                            }
+                            val blackFrame = Bitmap.createBitmap(
+                                snapshot?.width ?: 1920,
+                                snapshot?.height ?: 1080,
+                                Bitmap.Config.ARGB_8888
+                            )
+                            snapshot?.recycle()
+                            currentStreamer.setVideoSource(BitmapSourceFactory(blackFrame))
+                            // 3s: covers camera2 teardown + new camera 3A convergence.
+                            delay(3000)
                         } else {
                             // Not streaming (preview-only): plain delay is sufficient.
                             delay(300)

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -55,7 +55,9 @@ import io.github.thibaultbee.streampack.core.elements.sources.IMediaProjectionSo
 import com.dimadesu.lifestreamer.utils.ObservableViewModel
 import com.dimadesu.lifestreamer.utils.dataStore
 import com.dimadesu.lifestreamer.utils.isEmpty
+import com.dimadesu.lifestreamer.utils.blurForTransition
 import com.dimadesu.lifestreamer.utils.setNextCameraId
+import io.github.thibaultbee.streampack.core.interfaces.setCameraId
 import com.dimadesu.lifestreamer.utils.toggleBackToFront
 import com.dimadesu.lifestreamer.utils.ReconnectTimer
 import io.github.thibaultbee.streampack.core.elements.sources.video.camera.extensions.cameras
@@ -2517,13 +2519,40 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
 
         val videoSource = currentStreamer.videoInput?.sourceFlow?.value
         if (videoSource is ICameraSource) {
+            // Compute the next camera ID from the current one while we still hold a
+            // confirmed ICameraSource reference — avoids a race if another switch runs
+            // concurrently and replaces the source before we enter the mutex.
+            val cameraManager = application.getSystemService(Context.CAMERA_SERVICE) as android.hardware.camera2.CameraManager
+            val cameras = cameraManager.cameraIdList.toList()
+            val currentIndex = cameras.indexOf(videoSource.cameraId)
+            val newCameraId = cameras[(currentIndex + 1) % cameras.size]
             viewModelScope.launch(defaultDispatcher) {
                 videoSourceMutex.withLock {
                     try {
-                        // Add delay before switching camera to allow previous camera to fully release
-                        // This prevents resource conflicts when hot-swapping cameras
-                        delay(300)
-                        currentStreamer.setNextCameraId(application)
+                        if (currentStreamer.isStreamingFlow.value == true) {
+                            // While streaming: inject a blurred frozen frame so the encoder
+                            // keeps producing output during the camera switch gap.  OBS / the
+                            // SRT receiver always has frames to decode and shows a deliberate
+                            // visual transition instead of a glitch or dropout.
+                            val frozenBlurred = try {
+                                currentStreamer.videoInput?.takeSnapshot(0)?.blurForTransition()
+                            } catch (e: Exception) {
+                                Log.w(TAG, "Could not take snapshot for transition, falling back to plain delay", e)
+                                null
+                            }
+                            if (frozenBlurred != null) {
+                                currentStreamer.setVideoSource(BitmapSourceFactory(frozenBlurred))
+                                // Give BitmapSource one or two frames to reach the encoder
+                                // before we tear down the bitmap source and open the new camera.
+                                delay(50)
+                            } else {
+                                delay(300)
+                            }
+                        } else {
+                            // Not streaming (preview-only): plain delay is sufficient.
+                            delay(300)
+                        }
+                        currentStreamer.setCameraId(newCameraId)
                         Log.i(TAG, "Camera toggled successfully")
                     } catch (e: Exception) {
                         Log.e(TAG, "Failed to toggle camera", e)

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -2503,6 +2503,52 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
         return true
     }
 
+    /**
+     * Switch to a specific camera by ID, injecting a blurred frozen frame during the
+     * transition so the encoder stays fed and OBS / SRT receivers see no gap.
+     * Falls back to a plain delay if snapshot fails or not currently streaming.
+     */
+    @RequiresPermission(Manifest.permission.CAMERA)
+    fun switchCameraWithTransition(cameraId: String) {
+        val currentStreamer = serviceStreamer
+        if (currentStreamer == null) {
+            Log.e(TAG, "Streamer service not available for camera switch")
+            _streamerErrorLiveData.postValue("Service not available")
+            return
+        }
+
+        viewModelScope.launch(defaultDispatcher) {
+            videoSourceMutex.withLock {
+                try {
+                    if (currentStreamer.isStreamingFlow.value == true) {
+                        val frozenBlurred = try {
+                            currentStreamer.videoInput?.takeSnapshot(0)?.blurForTransition()
+                        } catch (e: Exception) {
+                            Log.w(TAG, "Could not take snapshot for transition, falling back to plain delay", e)
+                            null
+                        }
+                        if (frozenBlurred != null) {
+                            currentStreamer.setVideoSource(BitmapSourceFactory(frozenBlurred))
+                            // 400ms: camera2 session teardown is async and takes ~180-300ms.
+                            // This gives the old camera time to fully release while the
+                            // blurred frozen frame keeps the encoder fed throughout.
+                            delay(400)
+                        } else {
+                            delay(400)
+                        }
+                    } else {
+                        delay(300)
+                    }
+                    currentStreamer.setCameraId(cameraId)
+                    Log.i(TAG, "Switched to camera $cameraId successfully")
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failed to switch camera", e)
+                    _streamerErrorLiveData.postValue("Camera switch failed: ${e.message}")
+                }
+            }
+        }
+    }
+
     @RequiresPermission(Manifest.permission.CAMERA)
     fun toggleCamera() {
         /**
@@ -2542,11 +2588,12 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                             }
                             if (frozenBlurred != null) {
                                 currentStreamer.setVideoSource(BitmapSourceFactory(frozenBlurred))
-                                // Give BitmapSource one or two frames to reach the encoder
-                                // before we tear down the bitmap source and open the new camera.
-                                delay(50)
+                                // 400ms: camera2 session teardown is async and takes ~180-300ms.
+                                // This gives the old camera time to fully release while the
+                                // blurred frozen frame keeps the encoder fed throughout.
+                                delay(400)
                             } else {
-                                delay(300)
+                                delay(400)
                             }
                         } else {
                             // Not streaming (preview-only): plain delay is sufficient.

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -2578,7 +2578,7 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                         // Without this delay the coroutine advances alphaMultiplier while render()
                         // is never called, making the start of the fade appear skipped.
                         delay(500)
-                        fadeTransitionAlpha(from = 0f, to = 1f, durationMs = 500)
+                        fadeTransitionAlpha(from = 0f, to = 1f, durationMs = 1500)
                     }
                     Log.i(TAG, "Switched to camera $cameraId successfully")
                 } catch (e: Exception) {
@@ -2647,7 +2647,7 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                             // Wait for the new camera to deliver its first frame before ramping
                             // alpha. See switchCameraWithTransition for the full explanation.
                             delay(500)
-                            fadeTransitionAlpha(from = 0f, to = 1f, durationMs = 500)
+                            fadeTransitionAlpha(from = 0f, to = 1f, durationMs = 1500)
                         }
                         Log.i(TAG, "Camera toggled successfully")
                     } catch (e: Exception) {

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -2503,10 +2503,35 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
     }
 
     /**
+     * Animates the GL surface processor alpha from [from] to [to] over [durationMs] ms.
+     * Runs on the calling coroutine — must be called from a coroutine context.
+     * No-ops if the service / processor factory is not available.
+     */
+    private suspend fun fadeTransitionAlpha(from: Float, to: Float, durationMs: Long) {
+        val factory = CameraStreamerService.surfaceProcessorFactory
+        val startTime = System.currentTimeMillis()
+        while (true) {
+            val elapsed = System.currentTimeMillis() - startTime
+            val t = (elapsed.toFloat() / durationMs).coerceIn(0f, 1f)
+            // Perceptual correction: display gamma (~2.2) makes a linear alpha
+            // ramp look non-uniform. Ease-in (t²) for brightening keeps early
+            // frames dark longer; ease-out (√t) for darkening drops brightness
+            // quickly at the start so the fade-out is clearly visible.
+            val eased = if (to > from) t * t else kotlin.math.sqrt(t.toDouble()).toFloat()
+            factory.setAlpha(from + (to - from) * eased)
+            if (t >= 1f) break
+            delay(16) // ~60 fps
+        }
+    }
+
+    /**
      * Switch to a specific camera by ID, injecting a black frame during the
      * transition so the encoder stays fed and OBS / SRT receivers see no gap.
      * The black frame is held long enough for the old camera to fully tear down
      * and the new camera's 3A (auto-exposure, AWB) to converge.
+     *
+     * GL alpha animation hides glitchy teardown frames (fade-out) and early 3A
+     * settling frames (fade-in) on both ends of the cut.
      */
     @RequiresPermission(Manifest.permission.CAMERA)
     fun switchCameraWithTransition(cameraId: String) {
@@ -2520,7 +2545,8 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
         viewModelScope.launch(defaultDispatcher) {
             videoSourceMutex.withLock {
                 try {
-                    if (currentStreamer.isStreamingFlow.value == true) {
+                    val isStreaming = currentStreamer.isStreamingFlow.value == true
+                    if (isStreaming) {
                         // Snapshot only to get current frame dimensions;
                         // fall back to 1920×1080 if it fails.
                         val snapshot = try {
@@ -2535,17 +2561,30 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                             Bitmap.Config.ARGB_8888
                         )
                         snapshot?.recycle()
+                        // Fade out — darken camera frames before the source switch so
+                        // dying-camera artifacts are never visible to the encoder.
+                        fadeTransitionAlpha(from = 1f, to = 0f, durationMs = 500)
                         currentStreamer.setVideoSource(BitmapSourceFactory(blackFrame))
-                        // 3s: covers camera2 teardown (~300ms) + new camera open +
-                        // 3A convergence (~1-1.5s) with margin to avoid any artifacts.
-                        delay(3000)
+                        // Black hold: covers camera2 teardown + new camera open.
+                        delay(500)
                     } else {
                         delay(300)
                     }
                     currentStreamer.setCameraId(cameraId)
+                    if (isStreaming) {
+                        // Wait for the new camera to deliver its first frame before ramping
+                        // alpha. setCameraId() returns after the device opens, but onFrameAvailable
+                        // fires only when hardware delivers the first frame (~200-400 ms later).
+                        // Without this delay the coroutine advances alphaMultiplier while render()
+                        // is never called, making the start of the fade appear skipped.
+                        delay(500)
+                        fadeTransitionAlpha(from = 0f, to = 1f, durationMs = 500)
+                    }
                     Log.i(TAG, "Switched to camera $cameraId successfully")
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to switch camera", e)
+                    // Always restore full alpha so streaming continues normally.
+                    CameraStreamerService.surfaceProcessorFactory.setAlpha(1f)
                     _streamerErrorLiveData.postValue("Camera switch failed: ${e.message}")
                 }
             }
@@ -2578,7 +2617,8 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
             viewModelScope.launch(defaultDispatcher) {
                 videoSourceMutex.withLock {
                     try {
-                        if (currentStreamer.isStreamingFlow.value == true) {
+                        val isStreaming = currentStreamer.isStreamingFlow.value == true
+                        if (isStreaming) {
                             // While streaming: inject a black frame so the encoder
                             // keeps producing output during the camera switch gap.
                             val snapshot = try {
@@ -2593,17 +2633,27 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                                 Bitmap.Config.ARGB_8888
                             )
                             snapshot?.recycle()
+                            // Fade out — darken camera frames before the source switch.
+                            fadeTransitionAlpha(from = 1f, to = 0f, durationMs = 500)
                             currentStreamer.setVideoSource(BitmapSourceFactory(blackFrame))
-                            // 3s: covers camera2 teardown + new camera 3A convergence.
-                            delay(3000)
+                            // Black hold: covers camera2 teardown + new camera open.
+                            delay(500)
                         } else {
                             // Not streaming (preview-only): plain delay is sufficient.
                             delay(300)
                         }
                         currentStreamer.setCameraId(newCameraId)
+                        if (isStreaming) {
+                            // Wait for the new camera to deliver its first frame before ramping
+                            // alpha. See switchCameraWithTransition for the full explanation.
+                            delay(500)
+                            fadeTransitionAlpha(from = 0f, to = 1f, durationMs = 500)
+                        }
                         Log.i(TAG, "Camera toggled successfully")
                     } catch (e: Exception) {
                         Log.e(TAG, "Failed to toggle camera", e)
+                        // Always restore full alpha so streaming continues normally.
+                        CameraStreamerService.surfaceProcessorFactory.setAlpha(1f)
                         _streamerErrorLiveData.postValue("Camera toggle failed: ${e.message}")
                     }
                 }

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -2521,7 +2521,7 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                     val isStreaming = currentStreamer.isStreamingFlow.value == true
                     if (isStreaming) {
                         // Go fully dark instantly to hide teardown/startup glitches.
-                        CameraStreamerService.surfaceProcessorFactory.setAlpha(0f)
+                        CameraStreamerService.surfaceProcessorFactory.setBrightness(0f)
                     }
                     // Camera→camera path properly waits for the old camera's onClosed
                     // callback before opening the new one — no "Max cameras in use" error.
@@ -2529,13 +2529,13 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                     if (isStreaming) {
                         // Hold black while new camera delivers first frames and 3A settles.
                         delay(500)
-                        CameraStreamerService.surfaceProcessorFactory.setAlpha(1f)
+                        CameraStreamerService.surfaceProcessorFactory.setBrightness(1f)
                     }
                     Log.i(TAG, "Switched to camera $cameraId successfully")
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to switch camera", e)
-                    // Always restore full alpha so streaming continues normally.
-                    CameraStreamerService.surfaceProcessorFactory.setAlpha(1f)
+                    // Always restore full brightness so streaming continues normally.
+                    CameraStreamerService.surfaceProcessorFactory.setBrightness(1f)
                     _streamerErrorLiveData.postValue("Camera switch failed: ${e.message}")
                 }
             }
@@ -2571,7 +2571,7 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                         val isStreaming = currentStreamer.isStreamingFlow.value == true
                         if (isStreaming) {
                             // Go fully dark instantly to hide teardown/startup glitches.
-                            CameraStreamerService.surfaceProcessorFactory.setAlpha(0f)
+                            CameraStreamerService.surfaceProcessorFactory.setBrightness(0f)
                         }
                         // Camera→camera path properly waits for the old camera's onClosed
                         // callback before opening the new one — no "Max cameras in use" error.
@@ -2579,13 +2579,13 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                         if (isStreaming) {
                             // Hold black while new camera delivers first frames and 3A settles.
                             delay(500)
-                            CameraStreamerService.surfaceProcessorFactory.setAlpha(1f)
+                            CameraStreamerService.surfaceProcessorFactory.setBrightness(1f)
                         }
                         Log.i(TAG, "Camera toggled successfully")
                     } catch (e: Exception) {
                         Log.e(TAG, "Failed to toggle camera", e)
-                        // Always restore full alpha so streaming continues normally.
-                        CameraStreamerService.surfaceProcessorFactory.setAlpha(1f)
+                        // Always restore full brightness so streaming continues normally.
+                        CameraStreamerService.surfaceProcessorFactory.setBrightness(1f)
                         _streamerErrorLiveData.postValue("Camera toggle failed: ${e.message}")
                     }
                 }

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -2556,9 +2556,10 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                     // callback before opening the new one — no "Max cameras in use" error.
                     currentStreamer.setCameraId(cameraId)
                     if (isStreaming) {
-                        // t² easing keeps alpha near 0 during hardware warmup
-                        // (~200-400ms before first frame arrives), so no explicit
-                        // delay is needed before starting the fade-in.
+                        // Wait for the new camera to deliver its first frame before ramping
+                        // alpha. setCameraId() returns after the device opens, but onFrameAvailable
+                        // fires only when hardware delivers the first frame (~200-400 ms later).
+                        delay(500)
                         fadeTransitionAlpha(from = 0f, to = 1f, durationMs = 1500)
                     }
                     Log.i(TAG, "Switched to camera $cameraId successfully")
@@ -2610,9 +2611,10 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                         // callback before opening the new one — no "Max cameras in use" error.
                         currentStreamer.setCameraId(newCameraId)
                         if (isStreaming) {
-                            // t² easing keeps alpha near 0 during hardware warmup
-                            // (~200-400ms before first frame arrives), so no explicit
-                            // delay is needed before starting the fade-in.
+                            // Wait for the new camera to deliver its first frame before ramping
+                            // alpha. setCameraId() returns after the device opens, but onFrameAvailable
+                            // fires only when hardware delivers the first frame (~200-400 ms later).
+                            delay(500)
                             fadeTransitionAlpha(from = 0f, to = 1f, durationMs = 1500)
                         }
                         Log.i(TAG, "Camera toggled successfully")

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -2563,7 +2563,7 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                         snapshot?.recycle()
                         // Fade out — darken camera frames before the source switch so
                         // dying-camera artifacts are never visible to the encoder.
-                        fadeTransitionAlpha(from = 1f, to = 0f, durationMs = 500)
+                        fadeTransitionAlpha(from = 1f, to = 0f, durationMs = 250)
                         currentStreamer.setVideoSource(BitmapSourceFactory(blackFrame))
                         // Black hold: covers camera2 teardown + new camera open.
                         delay(500)
@@ -2634,7 +2634,7 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                             )
                             snapshot?.recycle()
                             // Fade out — darken camera frames before the source switch.
-                            fadeTransitionAlpha(from = 1f, to = 0f, durationMs = 500)
+                            fadeTransitionAlpha(from = 1f, to = 0f, durationMs = 250)
                             currentStreamer.setVideoSource(BitmapSourceFactory(blackFrame))
                             // Black hold: covers camera2 teardown + new camera open.
                             delay(500)

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -2547,37 +2547,18 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                 try {
                     val isStreaming = currentStreamer.isStreamingFlow.value == true
                     if (isStreaming) {
-                        // Snapshot only to get current frame dimensions;
-                        // fall back to 1920×1080 if it fails.
-                        val snapshot = try {
-                            currentStreamer.videoInput?.takeSnapshot(0)
-                        } catch (e: Exception) {
-                            Log.w(TAG, "Could not take snapshot for transition frame size", e)
-                            null
-                        }
-                        val blackFrame = Bitmap.createBitmap(
-                            snapshot?.width ?: 1920,
-                            snapshot?.height ?: 1080,
-                            Bitmap.Config.ARGB_8888
-                        )
-                        snapshot?.recycle()
-                        // Fade out — darken camera frames before the source switch so
-                        // dying-camera artifacts are never visible to the encoder.
+                        // Fade out while old camera is still running — no bitmap needed.
                         fadeTransitionAlpha(from = 1f, to = 0f, durationMs = 250)
-                        currentStreamer.setVideoSource(BitmapSourceFactory(blackFrame))
-                        // Black hold: covers camera2 teardown + new camera open.
-                        delay(500)
                     } else {
                         delay(300)
                     }
+                    // Camera→camera path properly waits for the old camera's onClosed
+                    // callback before opening the new one — no "Max cameras in use" error.
                     currentStreamer.setCameraId(cameraId)
                     if (isStreaming) {
-                        // Wait for the new camera to deliver its first frame before ramping
-                        // alpha. setCameraId() returns after the device opens, but onFrameAvailable
-                        // fires only when hardware delivers the first frame (~200-400 ms later).
-                        // Without this delay the coroutine advances alphaMultiplier while render()
-                        // is never called, making the start of the fade appear skipped.
-                        delay(500)
+                        // t² easing keeps alpha near 0 during hardware warmup
+                        // (~200-400ms before first frame arrives), so no explicit
+                        // delay is needed before starting the fade-in.
                         fadeTransitionAlpha(from = 0f, to = 1f, durationMs = 1500)
                     }
                     Log.i(TAG, "Switched to camera $cameraId successfully")
@@ -2619,34 +2600,19 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                     try {
                         val isStreaming = currentStreamer.isStreamingFlow.value == true
                         if (isStreaming) {
-                            // While streaming: inject a black frame so the encoder
-                            // keeps producing output during the camera switch gap.
-                            val snapshot = try {
-                                currentStreamer.videoInput?.takeSnapshot(0)
-                            } catch (e: Exception) {
-                                Log.w(TAG, "Could not take snapshot for transition frame size", e)
-                                null
-                            }
-                            val blackFrame = Bitmap.createBitmap(
-                                snapshot?.width ?: 1920,
-                                snapshot?.height ?: 1080,
-                                Bitmap.Config.ARGB_8888
-                            )
-                            snapshot?.recycle()
-                            // Fade out — darken camera frames before the source switch.
+                            // Fade out while old camera is still running — no bitmap needed.
                             fadeTransitionAlpha(from = 1f, to = 0f, durationMs = 250)
-                            currentStreamer.setVideoSource(BitmapSourceFactory(blackFrame))
-                            // Black hold: covers camera2 teardown + new camera open.
-                            delay(500)
                         } else {
                             // Not streaming (preview-only): plain delay is sufficient.
                             delay(300)
                         }
+                        // Camera→camera path properly waits for the old camera's onClosed
+                        // callback before opening the new one — no "Max cameras in use" error.
                         currentStreamer.setCameraId(newCameraId)
                         if (isStreaming) {
-                            // Wait for the new camera to deliver its first frame before ramping
-                            // alpha. See switchCameraWithTransition for the full explanation.
-                            delay(500)
+                            // t² easing keeps alpha near 0 during hardware warmup
+                            // (~200-400ms before first frame arrives), so no explicit
+                            // delay is needed before starting the fade-in.
                             fadeTransitionAlpha(from = 0f, to = 1f, durationMs = 1500)
                         }
                         Log.i(TAG, "Camera toggled successfully")

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -2547,20 +2547,16 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                 try {
                     val isStreaming = currentStreamer.isStreamingFlow.value == true
                     if (isStreaming) {
-                        // Fade out while old camera is still running — no bitmap needed.
-                        fadeTransitionAlpha(from = 1f, to = 0f, durationMs = 250)
-                    } else {
-                        delay(300)
+                        // Go fully dark instantly to hide teardown/startup glitches.
+                        CameraStreamerService.surfaceProcessorFactory.setAlpha(0f)
                     }
                     // Camera→camera path properly waits for the old camera's onClosed
                     // callback before opening the new one — no "Max cameras in use" error.
                     currentStreamer.setCameraId(cameraId)
                     if (isStreaming) {
-                        // Wait for the new camera to deliver its first frame before ramping
-                        // alpha. setCameraId() returns after the device opens, but onFrameAvailable
-                        // fires only when hardware delivers the first frame (~200-400 ms later).
+                        // Hold black while new camera delivers first frames and 3A settles.
                         delay(500)
-                        fadeTransitionAlpha(from = 0f, to = 1f, durationMs = 1500)
+                        CameraStreamerService.surfaceProcessorFactory.setAlpha(1f)
                     }
                     Log.i(TAG, "Switched to camera $cameraId successfully")
                 } catch (e: Exception) {
@@ -2601,21 +2597,16 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                     try {
                         val isStreaming = currentStreamer.isStreamingFlow.value == true
                         if (isStreaming) {
-                            // Fade out while old camera is still running — no bitmap needed.
-                            fadeTransitionAlpha(from = 1f, to = 0f, durationMs = 250)
-                        } else {
-                            // Not streaming (preview-only): plain delay is sufficient.
-                            delay(300)
+                            // Go fully dark instantly to hide teardown/startup glitches.
+                            CameraStreamerService.surfaceProcessorFactory.setAlpha(0f)
                         }
                         // Camera→camera path properly waits for the old camera's onClosed
                         // callback before opening the new one — no "Max cameras in use" error.
                         currentStreamer.setCameraId(newCameraId)
                         if (isStreaming) {
-                            // Wait for the new camera to deliver its first frame before ramping
-                            // alpha. setCameraId() returns after the device opens, but onFrameAvailable
-                            // fires only when hardware delivers the first frame (~200-400 ms later).
+                            // Hold black while new camera delivers first frames and 3A settles.
                             delay(500)
-                            fadeTransitionAlpha(from = 0f, to = 1f, durationMs = 1500)
+                            CameraStreamerService.surfaceProcessorFactory.setAlpha(1f)
                         }
                         Log.i(TAG, "Camera toggled successfully")
                     } catch (e: Exception) {

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -55,7 +55,6 @@ import io.github.thibaultbee.streampack.core.elements.sources.IMediaProjectionSo
 import com.dimadesu.lifestreamer.utils.ObservableViewModel
 import com.dimadesu.lifestreamer.utils.dataStore
 import com.dimadesu.lifestreamer.utils.isEmpty
-import com.dimadesu.lifestreamer.utils.setNextCameraId
 import io.github.thibaultbee.streampack.core.interfaces.setCameraId
 import com.dimadesu.lifestreamer.utils.toggleBackToFront
 import com.dimadesu.lifestreamer.utils.ReconnectTimer
@@ -2504,8 +2503,8 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
 
     /**
      * Switch to a specific camera by ID with a black hold during the transition.
-     * Instantly cuts to black, waits 5s on the old camera, switches, holds 500ms
-     * for the new camera's first frame, then snaps back to full brightness.
+     * Instantly cuts to black, switches camera, holds 500ms for 3A to settle,
+     * then restores full brightness.
      */
     @RequiresPermission(Manifest.permission.CAMERA)
     fun switchCameraWithTransition(cameraId: String) {

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -2503,35 +2503,9 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
     }
 
     /**
-     * Animates the GL surface processor alpha from [from] to [to] over [durationMs] ms.
-     * Runs on the calling coroutine — must be called from a coroutine context.
-     * No-ops if the service / processor factory is not available.
-     */
-    private suspend fun fadeTransitionAlpha(from: Float, to: Float, durationMs: Long) {
-        val factory = CameraStreamerService.surfaceProcessorFactory
-        val startTime = System.currentTimeMillis()
-        while (true) {
-            val elapsed = System.currentTimeMillis() - startTime
-            val t = (elapsed.toFloat() / durationMs).coerceIn(0f, 1f)
-            // Perceptual correction: display gamma (~2.2) makes a linear alpha
-            // ramp look non-uniform. Ease-in (t²) for brightening keeps early
-            // frames dark longer; ease-out (√t) for darkening drops brightness
-            // quickly at the start so the fade-out is clearly visible.
-            val eased = if (to > from) t * t else kotlin.math.sqrt(t.toDouble()).toFloat()
-            factory.setAlpha(from + (to - from) * eased)
-            if (t >= 1f) break
-            delay(16) // ~60 fps
-        }
-    }
-
-    /**
-     * Switch to a specific camera by ID, injecting a black frame during the
-     * transition so the encoder stays fed and OBS / SRT receivers see no gap.
-     * The black frame is held long enough for the old camera to fully tear down
-     * and the new camera's 3A (auto-exposure, AWB) to converge.
-     *
-     * GL alpha animation hides glitchy teardown frames (fade-out) and early 3A
-     * settling frames (fade-in) on both ends of the cut.
+     * Switch to a specific camera by ID with a black hold during the transition.
+     * Instantly cuts to black, waits 5s on the old camera, switches, holds 500ms
+     * for the new camera's first frame, then snaps back to full brightness.
      */
     @RequiresPermission(Manifest.permission.CAMERA)
     fun switchCameraWithTransition(cameraId: String) {

--- a/app/src/main/java/com/dimadesu/lifestreamer/utils/Extensions.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/utils/Extensions.kt
@@ -18,6 +18,7 @@ package com.dimadesu.lifestreamer.utils
 import android.Manifest
 import android.content.ContentValues
 import android.content.Context
+import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Build
 import android.provider.MediaStore
@@ -33,20 +34,38 @@ import io.github.thibaultbee.streampack.core.elements.sources.video.camera.exten
 import io.github.thibaultbee.streampack.core.interfaces.IWithVideoSource
 import io.github.thibaultbee.streampack.core.interfaces.setCameraId
 
+/**
+ * Returns the camera ID that [setNextCameraId] would switch to, without performing the switch.
+ */
 @RequiresPermission(Manifest.permission.CAMERA)
-suspend fun IWithVideoSource.setNextCameraId(context: Context) {
+fun IWithVideoSource.getNextCameraId(context: Context): String {
     val cameraManager = context.getSystemService(Context.CAMERA_SERVICE) as android.hardware.camera2.CameraManager
     val cameras = cameraManager.cameraIdList.toList()
     val videoSource = videoInput?.sourceFlow?.value
-
-    val newCameraId = if (videoSource is ICameraSource) {
-        val currentCameraIndex = cameras.indexOf(videoSource.cameraId)
-        (currentCameraIndex + 1) % cameras.size
+    val newCameraIndex = if (videoSource is ICameraSource) {
+        (cameras.indexOf(videoSource.cameraId) + 1) % cameras.size
     } else {
         0
     }
+    return cameras[newCameraIndex]
+}
 
-    setCameraId(cameras[newCameraId])
+@RequiresPermission(Manifest.permission.CAMERA)
+suspend fun IWithVideoSource.setNextCameraId(context: Context) {
+    setCameraId(getNextCameraId(context))
+}
+
+/**
+ * Returns a blurred copy of this bitmap suitable for use as a transition frame.
+ *
+ * Achieved by scaling down to 1/8 size and back up with bilinear filtering —
+ * fast, allocation-light, and works on API 24+.
+ */
+fun Bitmap.blurForTransition(): Bitmap {
+    val smallWidth = (width / 8).coerceAtLeast(1)
+    val smallHeight = (height / 8).coerceAtLeast(1)
+    val small = Bitmap.createScaledBitmap(this, smallWidth, smallHeight, true)
+    return Bitmap.createScaledBitmap(small, width, height, true)
 }
 
 @RequiresPermission(Manifest.permission.CAMERA)

--- a/app/src/main/java/com/dimadesu/lifestreamer/utils/Extensions.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/utils/Extensions.kt
@@ -55,18 +55,6 @@ suspend fun IWithVideoSource.setNextCameraId(context: Context) {
     setCameraId(getNextCameraId(context))
 }
 
-/**
- * Returns a blurred copy of this bitmap suitable for use as a transition frame.
- *
- * Achieved by scaling down to 1/8 size and back up with bilinear filtering —
- * fast, allocation-light, and works on API 24+.
- */
-fun Bitmap.blurForTransition(): Bitmap {
-    val smallWidth = (width / 8).coerceAtLeast(1)
-    val smallHeight = (height / 8).coerceAtLeast(1)
-    val small = Bitmap.createScaledBitmap(this, smallWidth, smallHeight, true)
-    return Bitmap.createScaledBitmap(small, width, height, true)
-}
 
 @RequiresPermission(Manifest.permission.CAMERA)
 suspend fun IWithVideoSource.toggleBackToFront(context: Context) {


### PR DESCRIPTION
When toggling built-in cameras while streaming, the encoder was starved during the ~300ms source switch gap, causing glitches in OBS media source.

Now captures the last video frame via takeSnapshot(), applies a fast scale-down/up blur, and feeds it to the encoder as a BitmapSource before switching cameras. The encoder stays fed throughout the transition.

Falls back to the original 300ms delay if snapshot fails. Preview-only (not streaming) behavior is unchanged.