### PR TITLE
Fix: when not streaming with USB source toggled on after orientation change preview stops working and RTMP SRC button is shown (should be hidden)

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -1108,7 +1108,9 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
         // First button (index 1) from XML
         binding.switchSourceButton.backgroundTintList = getButtonColorStateList(ctx, activeIndex == 1)
         binding.switchSourceButton.visibility =
-            if (activeIndex != null && activeIndex != 1) View.GONE else View.VISIBLE
+            if (activeIndex != null && activeIndex != 1) View.GONE
+            else if (previewViewModel.isUvcSource.value == true) View.GONE
+            else View.VISIBLE
 
         // Dynamic buttons (index 2, 3, ...)
         val container = binding.rtmpSourceButtonsContainer

--- a/app/src/main/java/com/dimadesu/lifestreamer/uvc/UvcVideoSource.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/uvc/UvcVideoSource.kt
@@ -303,8 +303,10 @@ class UvcVideoSource(
 
             mainHandler.post {
                 try {
-                    if (surfaceProcessor != null && inputSurface != null) {
-                        cameraHelper.addSurface(inputSurface, false)
+                    val surface = if (surfaceProcessor != null && inputSurface != null) inputSurface
+                                  else previewSurface
+                    if (surface != null) {
+                        cameraHelper.addSurface(surface, false)
                         if (isCameraReady) {
                             // Camera is already open (e.g. after orientation change) — restart preview.
                             try {
@@ -314,19 +316,7 @@ class UvcVideoSource(
                                 Log.d(TAG, "startPreview in startPreview(): ${e.message} (may be normal)")
                             }
                         } else {
-                            Log.d(TAG, "Added input surface for preview (camera will start when ready)")
-                        }
-                    } else if (previewSurface != null) {
-                        cameraHelper.addSurface(previewSurface, false)
-                        if (isCameraReady) {
-                            try {
-                                cameraHelper.startPreview()
-                                Log.d(TAG, "Restarted camera preview via preview surface")
-                            } catch (e: Exception) {
-                                Log.d(TAG, "startPreview in startPreview(): ${e.message} (may be normal)")
-                            }
-                        } else {
-                            Log.d(TAG, "Added preview surface directly (camera will start when ready)")
+                            Log.d(TAG, "Added surface for preview (camera will start when ready)")
                         }
                     }
                 } catch (e: Exception) {

--- a/app/src/main/java/com/dimadesu/lifestreamer/uvc/UvcVideoSource.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/uvc/UvcVideoSource.kt
@@ -303,15 +303,31 @@ class UvcVideoSource(
 
             mainHandler.post {
                 try {
-                    // Just add the surface - don't call cameraHelper.startPreview() here.
-                    // The camera might not be open yet; onCameraOpen callback handles starting preview.
-                    // If camera is already open and streaming, adding the surface will receive frames.
                     if (surfaceProcessor != null && inputSurface != null) {
                         cameraHelper.addSurface(inputSurface, false)
-                        Log.d(TAG, "Added input surface for preview (camera will start when ready)")
+                        if (isCameraReady) {
+                            // Camera is already open (e.g. after orientation change) — restart preview.
+                            try {
+                                cameraHelper.startPreview()
+                                Log.d(TAG, "Restarted camera preview (camera was already ready)")
+                            } catch (e: Exception) {
+                                Log.d(TAG, "startPreview in startPreview(): ${e.message} (may be normal)")
+                            }
+                        } else {
+                            Log.d(TAG, "Added input surface for preview (camera will start when ready)")
+                        }
                     } else if (previewSurface != null) {
                         cameraHelper.addSurface(previewSurface, false)
-                        Log.d(TAG, "Added preview surface directly (camera will start when ready)")
+                        if (isCameraReady) {
+                            try {
+                                cameraHelper.startPreview()
+                                Log.d(TAG, "Restarted camera preview via preview surface")
+                            } catch (e: Exception) {
+                                Log.d(TAG, "startPreview in startPreview(): ${e.message} (may be normal)")
+                            }
+                        } else {
+                            Log.d(TAG, "Added preview surface directly (camera will start when ready)")
+                        }
                     }
                 } catch (e: Exception) {
                     Log.e(TAG, "Error starting preview: ${e.message}", e)

--- a/app/src/main/java/com/dimadesu/lifestreamer/uvc/UvcVideoSource.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/uvc/UvcVideoSource.kt
@@ -308,7 +308,8 @@ class UvcVideoSource(
                     if (surface != null) {
                         cameraHelper.addSurface(surface, false)
                         if (isCameraReady) {
-                            // Camera is already open (e.g. after orientation change) — restart preview.
+                            // Camera is already open (e.g. after orientation change) — must call
+                            // startPreview() explicitly because onCameraOpen won't fire again.
                             try {
                                 cameraHelper.startPreview()
                                 Log.d(TAG, "Restarted camera preview (camera was already ready)")
@@ -316,6 +317,8 @@ class UvcVideoSource(
                                 Log.d(TAG, "startPreview in startPreview(): ${e.message} (may be normal)")
                             }
                         } else {
+                            // Camera not open yet — don't call startPreview() here.
+                            // The onCameraOpen callback will handle it once the camera is ready.
                             Log.d(TAG, "Added surface for preview (camera will start when ready)")
                         }
                     }


### PR DESCRIPTION
The bug had two separate symptoms, each with its own cause:

1. Preview went black after rotating

When you rotate, Android tears down and rebuilds the UI surface (the "window" that frames are drawn onto). StreamPack's PreviewView responds by calling stopPreview() on the UVC source, then startPreview() with the new surface.

The problem: startPreview() in UvcVideoSource only added the surface to the camera helper — it assumed the camera wasn't open yet and would start itself when ready. But the camera was already open from before the rotation, so that callback never fired again. The camera just sat there with the new surface attached but never told to start sending frames.

Fix: In startPreview(), check if isCameraReady is true. If so, explicitly call cameraHelper.startPreview() to kick the camera back into action with the new surface.

2. RTMP SRC button appeared when it should be hidden

The button's visibility is controlled in two places: a data binding expression in XML (goneUnless="!isUvcSource && ...") and a Kotlin function updateRtmpButtonColors() that sets visibility in code.

The data binding was correct — it hid the button when UVC was active. But updateRtmpButtonColors() was also called every time the activeRtmpIndex LiveData re-delivered its value to the new fragment after rotation. Since no RTMP source was active, activeRtmpIndex was null, and the function unconditionally set the button to VISIBLE — overwriting what the data binding had correctly set to GONE.

Fix: Make updateRtmpButtonColors() also check isUvcSource before setting the button to visible. If UVC is active, keep the button GONE regardless of the RTMP index.