### PR TITLE
Fix: prevent native crash in USB source stopPreview on screen off/on

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/uvc/UvcVideoSource.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/uvc/UvcVideoSource.kt
@@ -338,21 +338,11 @@ class UvcVideoSource(
             previewSurfaceOutput = null
         }
 
-        mainHandler.post {
-            try {
-                // If streaming is active, keep camera running
-                if (!_isStreamingFlow.value) {
-                    cameraHelper.stopPreview()
-                    Log.d(TAG, "Stopped camera preview")
-                } else {
-                    Log.d(TAG, "Streaming active - keeping camera running")
-                }
-            } catch (e: Exception) {
-                Log.e(TAG, "Error stopping preview: ${e.message}", e)
-            }
-        }
-
-        // Schedule cleanup if both are inactive
+        // Don't call cameraHelper.stopPreview() directly here — use scheduled cleanup instead.
+        // Direct stop races with a subsequent startPreview() on the CameraHelper thread,
+        // causing a native crash in UVCPreview::stopPreview().
+        // The cleanup gives startPreview() a window to cancel it if preview restarts quickly
+        // (e.g. screen off/on, orientation change).
         schedulePendingCleanup(500) {
             if (!_isStreamingFlow.value && !_isPreviewingFlow.value) {
                 Log.d(TAG, "Full cleanup - stopping camera")


### PR DESCRIPTION
stopPreview() was calling cameraHelper.stopPreview() immediately AND scheduling a 500ms delayed cleanup. When the screen was unlocked, startPreview() fired cameraHelper.startPreview() shortly after. Both dispatched to CameraHelper's internal thread, racing in the native UVCPreview::stopPreview() and causing an abort in libUVCCamera.so.

Remove the immediate stopPreview() call and rely solely on the 500ms delayed cleanup. If startPreview() is called within that window (as it always is for screen off/on and orientation change), it cancels the pending cleanup, avoiding the native race entirely.