### PR TITLE
Use audio effects system that StreamPack SDK now provides for audio levels UI aka VU meters instead of a custom one

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/audio/VuMeterEffect.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/audio/VuMeterEffect.kt
@@ -1,0 +1,92 @@
+package com.dimadesu.lifestreamer.audio
+
+import io.github.thibaultbee.streampack.core.elements.data.RawFrame
+import io.github.thibaultbee.streampack.core.elements.processing.audio.IConsumerAudioEffect
+import java.nio.ByteOrder
+import kotlin.math.abs
+import kotlin.math.sqrt
+
+/**
+ * A VU meter audio effect that computes RMS and peak levels per channel.
+ *
+ * Implements [IConsumerAudioEffect] so it runs on a background coroutine with a
+ * deep-copied buffer — it does NOT block the capture thread.
+ *
+ * @param onLevel Called with computed audio levels for each audio frame.
+ */
+class VuMeterEffect(
+    private val onLevel: (AudioLevel) -> Unit
+) : IConsumerAudioEffect {
+
+    /**
+     * Number of audio channels (1 = mono, 2 = stereo).
+     * Update this when the audio configuration changes.
+     */
+    @Volatile
+    var channelCount: Int = 1
+
+    override fun consume(isMuted: Boolean, data: RawFrame) {
+        val buffer = data.rawBuffer
+        val position = buffer.position()
+        val remaining = buffer.limit() - position
+
+        if (remaining < 2) {
+            onLevel(AudioLevel.SILENT)
+            return
+        }
+
+        val readBuffer = buffer.duplicate()
+        readBuffer.position(position)
+        readBuffer.order(ByteOrder.LITTLE_ENDIAN)
+
+        var maxSampleLeft = 0
+        var maxSampleRight = 0
+        var sumSquaresLeft = 0.0
+        var sumSquaresRight = 0.0
+        var sampleCountLeft = 0
+        var sampleCountRight = 0
+
+        val isStereo = channelCount >= 2
+        var isLeftChannel = true
+
+        while (readBuffer.remaining() >= 2) {
+            val sample = readBuffer.short.toInt()
+            val absSample = abs(sample)
+            val sampleSquared = (sample.toLong() * sample.toLong()).toDouble()
+
+            if (!isStereo || isLeftChannel) {
+                if (absSample > maxSampleLeft) maxSampleLeft = absSample
+                sumSquaresLeft += sampleSquared
+                sampleCountLeft++
+            } else {
+                if (absSample > maxSampleRight) maxSampleRight = absSample
+                sumSquaresRight += sampleSquared
+                sampleCountRight++
+            }
+
+            if (isStereo) isLeftChannel = !isLeftChannel
+        }
+
+        val peakLeft = if (sampleCountLeft > 0) (maxSampleLeft / 32767f).coerceIn(0f, 1f) else 0f
+        val rmsLeft = if (sampleCountLeft > 0)
+            (sqrt(sumSquaresLeft / sampleCountLeft) / 32767.0).toFloat().coerceIn(0f, 1f) else 0f
+
+        val peakRight = if (sampleCountRight > 0) (maxSampleRight / 32767f).coerceIn(0f, 1f) else 0f
+        val rmsRight = if (sampleCountRight > 0)
+            (sqrt(sumSquaresRight / sampleCountRight) / 32767.0).toFloat().coerceIn(0f, 1f) else 0f
+
+        onLevel(
+            AudioLevel(
+                rms = rmsLeft,
+                peak = peakLeft,
+                rmsRight = rmsRight,
+                peakRight = peakRight,
+                isStereo = isStereo
+            )
+        )
+    }
+
+    override fun close() {
+        // nothing to release
+    }
+}

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -2393,6 +2393,7 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
     private var audioConfigObserverJob: kotlinx.coroutines.Job? = null
     private var startCaptureJob: kotlinx.coroutines.Job? = null
     private var stopCaptureJob: kotlinx.coroutines.Job? = null
+    private var vuMeterEffect: com.dimadesu.lifestreamer.audio.VuMeterEffect? = null
     
     /**
      * Set up audio level monitoring on the streamer's audio processor.
@@ -2405,6 +2406,16 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
             return
         }
         
+        // Remove any previous effect
+        vuMeterEffect?.let { audioProcessor.remove(it) }
+        
+        // Create new VuMeterEffect using IConsumerAudioEffect plugin (runs on background coroutine)
+        val effect = com.dimadesu.lifestreamer.audio.VuMeterEffect { levels ->
+            _audioLevelFlow.value = levels
+        }
+        vuMeterEffect = effect
+        audioProcessor.add(effect)
+        
         // Observe the streamer's audioConfigFlow for channel count changes
         audioConfigObserverJob?.cancel()
         audioConfigObserverJob = viewModelScope.launch {
@@ -2412,11 +2423,11 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                 if (audioConfig != null) {
                     try {
                         val channelCount = io.github.thibaultbee.streampack.core.elements.encoders.AudioCodecConfig.getNumberOfChannels(audioConfig.channelConfig)
-                        audioProcessor.channelCount = channelCount
+                        effect.channelCount = channelCount
                         Log.i(TAG, "Audio level monitoring: channelCount=$channelCount")
                     } catch (t: Throwable) {
                         Log.w(TAG, "Failed to get channel count: ${t.message}")
-                        audioProcessor.channelCount = 1
+                        effect.channelCount = 1
                     }
                 }
             }
@@ -2438,17 +2449,6 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
             }
         }
         
-        audioProcessor.audioLevelCallback = { levels ->
-            // Update the flow (this is called from audio thread, so be efficient)
-            _audioLevelFlow.value = com.dimadesu.lifestreamer.audio.AudioLevel(
-                rms = levels.rmsLeft,
-                peak = levels.peakLeft,
-                rmsRight = levels.rmsRight,
-                peakRight = levels.peakRight,
-                isStereo = levels.isStereo
-            )
-        }
-        
         Log.i(TAG, "Audio level monitoring enabled")
     }
     
@@ -2461,7 +2461,11 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
             audioConfigObserverJob = null
             startCaptureJob?.cancel()
             startCaptureJob = null
-            serviceStreamer?.audioInput?.processor?.audioLevelCallback = null
+            vuMeterEffect?.let { effect ->
+                serviceStreamer?.audioInput?.processor?.remove(effect)
+                effect.close()
+            }
+            vuMeterEffect = null
             _audioLevelFlow.value = com.dimadesu.lifestreamer.audio.AudioLevel.SILENT
             // stopCapture is a suspend function — launch it and let it complete independently
             val audioInput = serviceStreamer?.audioInput


### PR DESCRIPTION
Previously, audio level calculation was done inline on the capture thread via a custom audioLevelCallback property added to IAudioFrameProcessor/ AudioFrameProcessor in the StreamPack fork. ThibaultBee specifically flagged this approach as problematic (StreamPack issue #39):
- ran on the capture thread instead of a background coroutine
- only supported 16-bit PCM
- not scalable alongside other audio effects

Replace with the proper IConsumerAudioEffect plugin system ThibaultBee built in dev_v3_2 for exactly this purpose:

- Add VuMeterEffect implementing IConsumerAudioEffect. AudioFrameProcessor automatically dispatches it on a background coroutine with a deep-copied buffer, so it never blocks the capture thread.
- Update PreviewViewModel to add/remove VuMeterEffect via the processor's MutableList<IAudioEffect> interface. Channel count is tracked on the effect instance directly.
- Remove all fork-specific additions from StreamPack: AudioLevelData, AudioLevelCallback, channelCount, audioLevelCallback, and calculateAudioLevels() from IAudioFrameProcessor/AudioFrameProcessor. The StreamPack fork is now closer to upstream dev_v3_2.