### PR TITLE
Fix: Audio levels UI is not working after changing audio settings (such as changing stereo to mono) only when not streaming

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -227,7 +227,10 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                         }
                         try {
                             Log.i(TAG, "Applying pending audio config after UI resumed")
+                            val wasMonitoring = vuMeterEffect != null
+                            if (wasMonitoring) disableAudioLevelMonitoring()
                             streamer.setAudioConfig(config)
+                            if (wasMonitoring) setupAudioLevelMonitoring()
                         } catch (t: Throwable) {
                             Log.e(TAG, "setAudioConfig failed (deferred)", t)
                             _streamerErrorLiveData.postValue("setAudioConfig: ${t.message ?: t::class.java.simpleName}")
@@ -270,7 +273,10 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
             if (streamer != null && streamer.isStreamingFlow.value != true) {
                 try {
                     Log.i(TAG, "Applying pending audio config after permission granted")
+                    val wasMonitoring = vuMeterEffect != null
+                    if (wasMonitoring) disableAudioLevelMonitoring()
                     streamer.setAudioConfig(config)
+                    if (wasMonitoring) setupAudioLevelMonitoring()
                 } catch (t: Throwable) {
                     Log.e(TAG, "setAudioConfig failed (after permission)", t)
                     _streamerErrorLiveData.postValue("setAudioConfig: ${t.message ?: t::class.java.simpleName}")
@@ -1482,7 +1488,16 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                     ) {
                         config?.let {
                             try {
+                                // Stop VU meter capture before reconfiguring audio —
+                                // AudioRecord can't be reconfigured while recording.
+                                val wasMonitoring = vuMeterEffect != null
+                                if (wasMonitoring) {
+                                    disableAudioLevelMonitoring()
+                                }
                                 serviceStreamer?.setAudioConfig(it)
+                                if (wasMonitoring) {
+                                    setupAudioLevelMonitoring()
+                                }
                             } catch (t: Throwable) {
                                 Log.e(TAG, "setAudioConfig failed", t)
                                 _streamerErrorLiveData.postValue("setAudioConfig: ${t.message ?: t::class.java.simpleName}")

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -227,10 +227,7 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                         }
                         try {
                             Log.i(TAG, "Applying pending audio config after UI resumed")
-                            val wasMonitoring = vuMeterEffect != null
-                            if (wasMonitoring) disableAudioLevelMonitoring()
-                            streamer.setAudioConfig(config)
-                            if (wasMonitoring) setupAudioLevelMonitoring()
+                            applyAudioConfigSafely(streamer, config)
                         } catch (t: Throwable) {
                             Log.e(TAG, "setAudioConfig failed (deferred)", t)
                             _streamerErrorLiveData.postValue("setAudioConfig: ${t.message ?: t::class.java.simpleName}")
@@ -273,10 +270,7 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
             if (streamer != null && streamer.isStreamingFlow.value != true) {
                 try {
                     Log.i(TAG, "Applying pending audio config after permission granted")
-                    val wasMonitoring = vuMeterEffect != null
-                    if (wasMonitoring) disableAudioLevelMonitoring()
-                    streamer.setAudioConfig(config)
-                    if (wasMonitoring) setupAudioLevelMonitoring()
+                    applyAudioConfigSafely(streamer, config)
                 } catch (t: Throwable) {
                     Log.e(TAG, "setAudioConfig failed (after permission)", t)
                     _streamerErrorLiveData.postValue("setAudioConfig: ${t.message ?: t::class.java.simpleName}")
@@ -1488,16 +1482,7 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                     ) {
                         config?.let {
                             try {
-                                // Stop VU meter capture before reconfiguring audio —
-                                // AudioRecord can't be reconfigured while recording.
-                                val wasMonitoring = vuMeterEffect != null
-                                if (wasMonitoring) {
-                                    disableAudioLevelMonitoring()
-                                }
-                                serviceStreamer?.setAudioConfig(it)
-                                if (wasMonitoring) {
-                                    setupAudioLevelMonitoring()
-                                }
+                                serviceStreamer?.let { s -> applyAudioConfigSafely(s, it) }
                             } catch (t: Throwable) {
                                 Log.e(TAG, "setAudioConfig failed", t)
                                 _streamerErrorLiveData.postValue("setAudioConfig: ${t.message ?: t::class.java.simpleName}")
@@ -2494,6 +2479,18 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                 }
             }
         } catch (_: Throwable) {}
+    }
+
+    /**
+     * Apply an audio config change, pausing VU meter capture if active.
+     * AudioRecord can't be reconfigured while recording, so we must
+     * stop capture first and restart it after.
+     */
+    private suspend fun applyAudioConfigSafely(streamer: io.github.thibaultbee.streampack.core.streamers.single.SingleStreamer, config: io.github.thibaultbee.streampack.core.elements.encoders.AudioCodecConfig) {
+        val wasMonitoring = vuMeterEffect != null
+        if (wasMonitoring) disableAudioLevelMonitoring()
+        streamer.setAudioConfig(config)
+        if (wasMonitoring) setupAudioLevelMonitoring()
     }
 
     fun setMute(isMuted: Boolean) {


### PR DESCRIPTION
When the user changes audio settings (e.g. stereo→mono) while the VU meter is active, AudioRecord is in recording state via startCapture(). setAudioConfig() calls audioSource.configure() which throws IllegalStateException("Audio source is already running") — the config change fails silently and the meters keep the old channel layout.

Stop VU meter capture before applying the new audio config, then restart it after. This is needed in three code paths:
- audioConfigFlow collector (direct settings change)
- deferred config on UI resume (settings screen sends app to background)
- deferred config after permission grant