### PR TITLE
Fix app doesn't go into reconnection mode in some cases

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -1305,11 +1305,18 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
         viewModelScope.launch {
             serviceReadyFlow.collect { isReady ->
                 if (isReady) {
+                    // Track the previous value of isStreamingFlow itself rather than reading
+                    // streamStatus.value, because the service's onStreamingStopped callback sets
+                    // status to NOT_STREAMING a few ms BEFORE isStreamingFlow emits false.
+                    // Reading previousStatus at that point gives NOT_STREAMING even when the stream
+                    // was actively running, causing wasStreaming=false and suppressing reconnection.
+                    var previouslyStreaming = serviceStreamer?.isStreamingFlow?.value ?: false
                     serviceStreamer?.isStreamingFlow?.collect { isStreaming ->
                         val previousStatus = streamStatus.value
-                        Log.i(TAG, "isStreamingFlow changed: $isStreaming, previousStatus=$previousStatus, userStoppedManually=${service?.userStoppedManually?.value}, isReconnecting=${service?.isReconnecting?.value}")
+                        Log.i(TAG, "isStreamingFlow changed: $isStreaming, previouslyStreaming=$previouslyStreaming, previousStatus=$previousStatus, userStoppedManually=${service?.userStoppedManually?.value}, isReconnecting=${service?.isReconnecting?.value}")
                         
                         if (isStreaming) {
+                            previouslyStreaming = true
                             // Don't change to STREAMING during reconnection - keep CONNECTING status
                             // This ensures stop button works during reconnection attempts
                             if (service?.isReconnecting?.value != true) {
@@ -1318,9 +1325,12 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                                 Log.d(TAG, "Stream started during reconnection - keeping CONNECTING status for stop button")
                             }
                         } else {
-                            // Stream stopped - check if this was unexpected (should trigger reconnection)
-                            val wasStreaming = previousStatus == StreamStatus.STREAMING || 
-                                              previousStatus == StreamStatus.CONNECTING
+                            // Stream stopped - check if this was unexpected (should trigger reconnection).
+                            // Use previouslyStreaming (tracks actual isStreamingFlow transitions) instead
+                            // of previousStatus (which can be prematurely set to NOT_STREAMING by the
+                            // service's streaming-stopped callback before isStreamingFlow fires false).
+                            val wasStreaming = previouslyStreaming
+                            previouslyStreaming = false
                             
                             Log.d(TAG, "Stream stopped - wasStreaming=$wasStreaming, userStopped=${service?.userStoppedManually?.value}, isReconnecting=${service?.isReconnecting?.value}")
                             


### PR DESCRIPTION
**Root cause** — two problems combining to suppress reconnection:

1. **Race condition** (`CameraStreamerService` sets `NOT_STREAMING` ~4ms before `isStreamingFlow` emits `false`). The old code read `streamStatus.value` as `previousStatus`, so by the time the `isStreamingFlow` observer fired, the status was already `NOT_STREAMING` → `wasStreaming = false` → reconnect skipped silently.

2. **Silent socket close** — when you turn WiFi off in Android Settings, the OS closes the SRT UDP socket cleanly (no error), so no `ClosedException` is emitted to `throwableFlow`. The `isStreamingFlow` observer was the *only* remaining reconnect path — but bug #1 broke it.

**Fix** — in the `isStreamingFlow` observer, replaced the unreliable `previousStatus` check with a `var previouslyStreaming` local variable that tracks the actual previous value of the flow itself. It's initialized from `isStreamingFlow.value` (handles already-streaming case on attach), set to `true` when `isStreaming=true` fires, used as `wasStreaming` when `isStreaming=false` fires, then reset to `false`. This is completely independent of the service's status updates, so the race condition can no longer suppress reconnection.

---

The diff is clean and minimal. Let me analyze potential behavioral changes:

**Scenarios that now work differently:**

| Scenario | Old behavior | New behavior | Concern? |
|----------|-------------|-------------|----------|
| WiFi off → SRT socket silently closed | `wasStreaming=false` → no reconnect | `wasStreaming=true` → reconnect triggers | **Desired fix** |
| Service observer fires `NOT_STREAMING` before `isStreamingFlow=false` | Race → reconnection suppressed | Race irrelevant, tracked independently | **Desired fix** |

**Scenarios that remain unchanged:**

1. **User taps Stop** — `userStoppedManually=true` is set *before* anything else happens, so the `wasStreaming` check never reaches the reconnect branch. No change.

2. **Already reconnecting** — `isReconnecting=true` guard remains, prevents duplicate triggers. No change.

3. **Stream that never started** (`isStreamingFlow` was never `true`) — `previouslyStreaming` initializes from `isStreamingFlow.value` which is `false`, and is never set to `true`, so `wasStreaming=false` → goes to "Stream never started" path. No change.

4. **Service rebind after process death** — `previouslyStreaming` re-initializes from current `isStreamingFlow.value`. If the stream was running, it picks up `true`; if not, `false`. Same semantics as before.

**One edge case worth noting:**

If `isStreamingFlow` emits `true` → `false` → `false` rapidly (e.g., flicker), the first `false` sets `previouslyStreaming = false`, so the second `false` correctly gets `wasStreaming=false`. No double-reconnect. Safe.

**Verdict:** The fix is safe. The only behavioral change is that the reconnection now correctly triggers when WiFi drops silently — no other paths are affected.