### PR TITLE
Add SYS AUDIO button that records all audio played via device audio output and use it instead of built-in/USB/Bluetooth mic for stream. Allow for built-in and USB cameras (exclude for RTMP/SRT source)

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/audio/BluetoothAudioManager.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/audio/BluetoothAudioManager.kt
@@ -8,6 +8,7 @@ import android.media.AudioManager
 import android.util.Log
 import io.github.thibaultbee.streampack.core.interfaces.IWithAudioSource
 import io.github.thibaultbee.streampack.core.streamers.single.ISingleStreamer
+import io.github.thibaultbee.streampack.core.elements.sources.IMediaProjectionSource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -568,6 +569,12 @@ class BluetoothAudioManager(
             Log.i(TAG, "Recreating mic source to ensure clean audio session")
             scope.launch(Dispatchers.Default) {
                 try {
+                    val audioInput = (streamerInstance as? IWithAudioSource)?.audioInput
+                    // Don't overwrite MediaProjection audio source (e.g. SYS AUDIO active)
+                    if (audioInput?.sourceFlow?.value is IMediaProjectionSource) {
+                        Log.i(TAG, "Recreate mic source: skipped - MediaProjection audio is active")
+                        return@launch
+                    }
                     // After BT disconnect, current source is BluetoothAudioSource which won't match
                     // AudioRecord/Microphone in isSourceEquals, so recreation happens automatically.
                     // Factory will auto-detect USB and choose appropriate source type.

--- a/app/src/main/java/com/dimadesu/lifestreamer/audio/BluetoothAudioManager.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/audio/BluetoothAudioManager.kt
@@ -114,10 +114,14 @@ class BluetoothAudioManager(
                         delay(300)
                         
                         // Step 3: Recreate audio source with fresh AudioRecord
-                        Log.i(TAG, "applyPolicy disable: Step 3 - recreate audio source")
-                        audioStreamer?.setAudioSource(
-                            ConditionalAudioSourceFactory()
-                        )
+                        // Re-check in case SYS AUDIO was activated during SCO teardown delays
+                        val isMediaProjectionNow = audioStreamer?.audioInput?.sourceFlow?.value is IMediaProjectionSource
+                        if (isMediaProjectionNow) {
+                            Log.i(TAG, "applyPolicy disable: Step 3 skipped - MediaProjection audio now active")
+                        } else {
+                            Log.i(TAG, "applyPolicy disable: Step 3 - recreate audio source")
+                            audioStreamer?.setAudioSource(ConditionalAudioSourceFactory())
+                        }
                         
                         delay(150)
                         _scoStateFlow.tryEmit(ScoState.IDLE)

--- a/app/src/main/java/com/dimadesu/lifestreamer/audio/BluetoothAudioManager.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/audio/BluetoothAudioManager.kt
@@ -71,7 +71,7 @@ class BluetoothAudioManager(
      * @param streamer Optional streamer instance for audio source switching
      * @param isStreaming Whether currently streaming
      */
-    fun applyPolicy(enabled: Boolean, streamer: ISingleStreamer?, isStreaming: Boolean) {
+    fun applyPolicy(enabled: Boolean, streamer: ISingleStreamer?, isStreaming: Boolean, sysAudioTransition: Boolean = false) {
         BluetoothAudioConfig.setEnabled(enabled)
 
         if (!enabled) {
@@ -100,12 +100,16 @@ class BluetoothAudioManager(
                             return@launch
                         }
 
-                        // Step 1: Switch audio source while still on SCO
-                        Log.i(TAG, "applyPolicy disable: Step 1 - switch to built-in mic before SCO stop")
-                        audioStreamer?.setAudioSource(
-                            ConditionalAudioSourceFactory()
-                        )
-                        delay(200)
+                        // Step 1: Switch audio source while still on SCO.
+                        // Skip when SYS AUDIO is about to take over — setAudioSourceBasedOnVideoSource()
+                        // will set MP concurrently, and Step 1's factory create() can race and override it.
+                        if (sysAudioTransition) {
+                            Log.i(TAG, "applyPolicy disable: Step 1 skipped - SYS AUDIO transition")
+                        } else {
+                            Log.i(TAG, "applyPolicy disable: Step 1 - switch to built-in mic before SCO stop")
+                            audioStreamer?.setAudioSource(ConditionalAudioSourceFactory())
+                            delay(200)
+                        }
                         
                         // Step 2: Now stop SCO and reset audio mode
                         Log.i(TAG, "applyPolicy disable: Step 2 - stop SCO and reset audio")

--- a/app/src/main/java/com/dimadesu/lifestreamer/audio/BluetoothAudioManager.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/audio/BluetoothAudioManager.kt
@@ -88,9 +88,20 @@ class BluetoothAudioManager(
             if (streamer != null) {
                 scope.launch(Dispatchers.Default) {
                     try {
+                        val audioStreamer = streamer as? IWithAudioSource
+                        val isMediaProjectionActive = audioStreamer?.audioInput?.sourceFlow?.value is IMediaProjectionSource
+
+                        if (isMediaProjectionActive) {
+                            // SYS AUDIO is active — just stop SCO/cleanup, don't touch the audio source
+                            Log.i(TAG, "applyPolicy disable: MediaProjection audio active, only stopping SCO")
+                            stopScoAndResetAudio()
+                            BluetoothAudioConfig.setPreferredDevice(null)
+                            _scoStateFlow.tryEmit(ScoState.IDLE)
+                            return@launch
+                        }
+
                         // Step 1: Switch audio source while still on SCO
                         Log.i(TAG, "applyPolicy disable: Step 1 - switch to built-in mic before SCO stop")
-                        val audioStreamer = streamer as? IWithAudioSource
                         audioStreamer?.setAudioSource(
                             ConditionalAudioSourceFactory()
                         )

--- a/app/src/main/java/com/dimadesu/lifestreamer/audio/BluetoothAudioManager.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/audio/BluetoothAudioManager.kt
@@ -117,11 +117,14 @@ class BluetoothAudioManager(
                         BluetoothAudioConfig.setPreferredDevice(null)
                         delay(300)
                         
-                        // Step 3: Recreate audio source with fresh AudioRecord
-                        // Re-check in case SYS AUDIO was activated during SCO teardown delays
+                        // Step 3: Recreate audio source with fresh AudioRecord.
+                        // Skip when SYS AUDIO is taking over — ViewModel sets MP via
+                        // setAudioSourceBasedOnVideoSource() and any source switch here
+                        // would race and override it.
+                        // Also re-check at runtime in case SYS AUDIO activated during delays.
                         val isMediaProjectionNow = audioStreamer?.audioInput?.sourceFlow?.value is IMediaProjectionSource
-                        if (isMediaProjectionNow) {
-                            Log.i(TAG, "applyPolicy disable: Step 3 skipped - MediaProjection audio now active")
+                        if (sysAudioTransition || isMediaProjectionNow) {
+                            Log.i(TAG, "applyPolicy disable: Step 3 skipped - SYS AUDIO transition or MediaProjection now active")
                         } else {
                             Log.i(TAG, "applyPolicy disable: Step 3 - recreate audio source")
                             audioStreamer?.setAudioSource(ConditionalAudioSourceFactory())

--- a/app/src/main/java/com/dimadesu/lifestreamer/rtmp/audio/MediaProjectionAudioSource.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/rtmp/audio/MediaProjectionAudioSource.kt
@@ -15,16 +15,19 @@ import io.github.thibaultbee.streampack.core.elements.sources.audio.IAudioSource
 import io.github.thibaultbee.streampack.core.elements.sources.IMediaProjectionSource
 
 /**
- * App-local MediaProjection-based audio source that captures only app audio by UID filter.
- * This is a minimal implementation compatible with StreamPack's IAudioSourceInternal usage.
+ * App-local MediaProjection-based audio source.
+ *
+ * When [captureFullPhone] is false (default): captures only this app's own audio via UID filter.
+ * When [captureFullPhone] is true: captures all phone audio (media, games, unknown usage).
+ *
  * Implements IMediaProjectionSource so USB audio manager can detect when screen audio is in use.
  */
 @RequiresApi(Build.VERSION_CODES.Q)
 class MediaProjectionAudioSource(
-    override val mediaProjection: MediaProjection  // Make public for factory comparison
+    override val mediaProjection: MediaProjection,
+    private val captureFullPhone: Boolean = false
 ) : AudioRecordSource(), Releasable, IMediaProjectionSource {
 
-    // let AudioRecordSource.configure handle buffer sizing and processor setup
     override fun buildAudioRecord(config: AudioSourceConfig, bufferSize: Int): AudioRecord {
         val audioFormat = AudioFormat.Builder()
             .setEncoding(config.byteFormat)
@@ -32,26 +35,33 @@ class MediaProjectionAudioSource(
             .setChannelMask(config.channelConfig)
             .build()
 
+        val captureConfig = if (captureFullPhone) {
+            AudioPlaybackCaptureConfiguration.Builder(mediaProjection)
+                .addMatchingUsage(AudioAttributes.USAGE_MEDIA)
+                .addMatchingUsage(AudioAttributes.USAGE_GAME)
+                .addMatchingUsage(AudioAttributes.USAGE_UNKNOWN)
+                .build()
+        } else {
+            AudioPlaybackCaptureConfiguration.Builder(mediaProjection)
+                .addMatchingUid(Process.myUid())
+                .build()
+        }
+
         return AudioRecord.Builder()
             .setAudioFormat(audioFormat)
             .setBufferSizeInBytes(bufferSize)
-            .setAudioPlaybackCaptureConfig(
-                AudioPlaybackCaptureConfiguration.Builder(mediaProjection)
-                    .addMatchingUid(Process.myUid())
-                    .build()
-            )
+            .setAudioPlaybackCaptureConfig(captureConfig)
             .build()
     }
-
-    // Behavior (configure/start/stop/fill/get) is provided by AudioRecordSource.
 }
 
 @RequiresApi(Build.VERSION_CODES.Q)
 class MediaProjectionAudioSourceFactory(
-    private val mediaProjection: MediaProjection
+    private val mediaProjection: MediaProjection,
+    private val captureFullPhone: Boolean = false
 ) : IAudioSourceInternal.Factory {
     override suspend fun create(context: Context): IAudioSourceInternal {
-        return MediaProjectionAudioSource(mediaProjection)
+        return MediaProjectionAudioSource(mediaProjection, captureFullPhone)
     }
 
     override fun isSourceEquals(source: IAudioSourceInternal?): Boolean {

--- a/app/src/main/java/com/dimadesu/lifestreamer/rtmp/audio/MediaProjectionAudioSource.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/rtmp/audio/MediaProjectionAudioSource.kt
@@ -24,10 +24,11 @@ import io.github.thibaultbee.streampack.core.elements.sources.IMediaProjectionSo
  */
 @RequiresApi(Build.VERSION_CODES.Q)
 class MediaProjectionAudioSource(
-    override val mediaProjection: MediaProjection,
+    override val mediaProjection: MediaProjection,  // Make public for factory comparison
     private val captureFullPhone: Boolean = false
 ) : AudioRecordSource(), Releasable, IMediaProjectionSource {
 
+    // let AudioRecordSource.configure handle buffer sizing and processor setup
     override fun buildAudioRecord(config: AudioSourceConfig, bufferSize: Int): AudioRecord {
         val audioFormat = AudioFormat.Builder()
             .setEncoding(config.byteFormat)
@@ -53,6 +54,8 @@ class MediaProjectionAudioSource(
             .setAudioPlaybackCaptureConfig(captureConfig)
             .build()
     }
+
+    // Behavior (configure/start/stop/fill/get) is provided by AudioRecordSource.
 }
 
 @RequiresApi(Build.VERSION_CODES.Q)

--- a/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
@@ -1315,7 +1315,7 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
         // Attempt SCO whenever mic-based audio is active (pre-stream and during streaming).
         // Previously deferred pre-stream, but that left VU meters on built-in mic until stream start.
         val effectiveIsStreaming = !isMediaProjectionAudio
-        bluetoothAudioManager.applyPolicy(enabled, streamer, effectiveIsStreaming)
+        bluetoothAudioManager.applyPolicy(enabled, streamer, effectiveIsStreaming, sysAudioTransition = skipPassthroughRestart)
         
         if (isStreaming && isMediaProjectionAudio && enabled) {
             Log.i(TAG, "applyBluetoothPolicy: BT toggle ON but using MediaProjection audio - BT mic won't be used for streaming")

--- a/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
@@ -1263,8 +1263,8 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
         // Expose SCO state flow for UI (delegated to BluetoothAudioManager)
         fun scoStateFlow() = this@CameraStreamerService.bluetoothAudioManager.scoStateFlow
         // Allow bound clients to enable/disable Bluetooth mic policy at runtime
-        fun setUseBluetoothMic(enabled: Boolean) {
-            try { this@CameraStreamerService.applyBluetoothPolicy(enabled) } catch (_: Throwable) {}
+        fun setUseBluetoothMic(enabled: Boolean, skipPassthroughRestart: Boolean = false, forcePassthroughRestart: Boolean = false) {
+            try { this@CameraStreamerService.applyBluetoothPolicy(enabled, skipPassthroughRestart, forcePassthroughRestart) } catch (_: Throwable) {}
         }
     }
 
@@ -1300,8 +1300,11 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
      * Note: BT mic only applies when using mic-based audio, not MediaProjection.
      * 
      * @param enabled true to enable Bluetooth mic, false to disable
+     * @param skipPassthroughRestart true when SYS AUDIO is about to take over — avoids a
+     *        passthrough restart race where the service would restart with built-in mic just
+     *        before the ViewModel switches the stream source to MediaProjection.
      */
-    fun applyBluetoothPolicy(enabled: Boolean) {
+    fun applyBluetoothPolicy(enabled: Boolean, skipPassthroughRestart: Boolean = false, forcePassthroughRestart: Boolean = false) {
         val isStreaming = streamer?.isStreamingFlow?.value == true
         val passthroughWasRunning = _isPassthroughRunning.value
         
@@ -1318,8 +1321,11 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
             Log.i(TAG, "applyBluetoothPolicy: BT toggle ON but using MediaProjection audio - BT mic won't be used for streaming")
         }
         
-        // If passthrough is running, restart it to switch between BT and built-in mic
-        if (passthroughWasRunning) {
+        // If passthrough is running, restart it to switch between BT and built-in mic.
+        // Skip when SYS AUDIO is taking over — it will manage the passthrough itself.
+        // Force restart when transitioning from SYS AUDIO to BT — passthrough was stopped
+        // by SYS AUDIO so passthroughWasRunning is false, but monitoring should resume.
+        if ((passthroughWasRunning || forcePassthroughRestart) && !skipPassthroughRestart) {
             // Cancel any ongoing restart to prevent race conditions
             passthroughRestartJob?.cancel()
             

--- a/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
@@ -1266,6 +1266,10 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
         fun setUseBluetoothMic(enabled: Boolean, skipPassthroughRestart: Boolean = false, forcePassthroughRestart: Boolean = false) {
             try { this@CameraStreamerService.applyBluetoothPolicy(enabled, skipPassthroughRestart, forcePassthroughRestart) } catch (_: Throwable) {}
         }
+
+        fun refreshNotification() {
+            try { customNotificationUtils.notify(onCreateNotification()) } catch (_: Throwable) {}
+        }
     }
 
     private val customBinder = CameraStreamerServiceBinder()

--- a/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
@@ -1268,7 +1268,10 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
         }
 
         fun refreshNotification() {
-            try { customNotificationUtils.notify(onCreateNotification()) } catch (_: Throwable) {}
+            try {
+                val (notification, _) = buildNotificationForStatus(_serviceStreamStatus.value)
+                customNotificationUtils.notify(notification)
+            } catch (_: Throwable) {}
         }
     }
 

--- a/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
@@ -1511,16 +1511,15 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
                 _isPassthroughRunning.tryEmit(false)
                 Log.i(TAG, "Audio passthrough stopped")
                 
-                // Only stop SCO if streaming is NOT currently using Bluetooth
-                // Check if streamer is streaming and using BluetoothAudioSource
-                val isStreaming = streamer?.isStreamingFlow?.value == true
+                // Keep SCO active if the streamer is already using BluetoothAudioSource —
+                // stopping SCO would fire a disconnect event and revert the stream source to
+                // built-in mic even though the BT toggle is still on.
                 val currentAudioSource = (streamer as? IWithAudioSource)?.audioInput?.sourceFlow?.value
-                val isStreamingWithBluetooth = isStreaming && currentAudioSource is BluetoothAudioSource
-                
-                if (isStreamingWithBluetooth) {
-                    Log.i(TAG, "Streaming is using Bluetooth - keeping SCO active")
+                val isUsingBluetooth = currentAudioSource is BluetoothAudioSource
+
+                if (isUsingBluetooth) {
+                    Log.i(TAG, "Stream source is Bluetooth - keeping SCO active after passthrough stop")
                 } else {
-                    // Stop SCO if started for passthrough and streaming is not using BT
                     bluetoothAudioManager.stopScoForPassthrough()
                 }
             } catch (e: Exception) {

--- a/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
@@ -1309,8 +1309,9 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
         val currentAudioSource = (streamer as? IWithAudioSource)?.audioInput?.sourceFlow?.value
         val isMediaProjectionAudio = currentAudioSource is IMediaProjectionSource
         
-        // Only apply BT policy for streaming if using mic-based audio
-        val effectiveIsStreaming = isStreaming && !isMediaProjectionAudio
+        // Attempt SCO whenever mic-based audio is active (pre-stream and during streaming).
+        // Previously deferred pre-stream, but that left VU meters on built-in mic until stream start.
+        val effectiveIsStreaming = !isMediaProjectionAudio
         bluetoothAudioManager.applyPolicy(enabled, streamer, effectiveIsStreaming)
         
         if (isStreaming && isMediaProjectionAudio && enabled) {

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -176,7 +176,7 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
         }
 
         binding.systemAudioToggleButton.setOnClickListener {
-            previewViewModel.toggleSystemAudioForCamera()
+            previewViewModel.toggleSystemAudioForCamera(mediaProjectionLauncher)
         }
 
         previewViewModel.useSystemAudioForCameraLiveData.observe(viewLifecycleOwner) { enabled ->
@@ -703,14 +703,6 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
         // when quickly going to settings and back (StreamPack fix 78f1dc28c)
         requestCameraAndMicrophonePermissions()
 
-        // Request MediaProjection once at startup for the audio mix feature
-        if (!previewViewModel.hasRequestedStartupMediaProjection) {
-            previewViewModel.hasRequestedStartupMediaProjection = true
-            previewViewModel.mediaProjectionHelper.requestProjection(mediaProjectionLauncher) { mp ->
-                previewViewModel.onStartupMediaProjectionAcquired(mp)
-            }
-        }
-        
         if (PermissionManager.hasPermissions(requireContext(), Manifest.permission.CAMERA)) {
             // FIRST: Restore orientation lock if streaming, BEFORE restarting preview
             // Get saved orientation from Service (source of truth)

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -180,7 +180,7 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
         }
 
         previewViewModel.useSystemAudioForCameraLiveData.observe(viewLifecycleOwner) { enabled ->
-            binding.systemAudioToggleButton.text = if (enabled) "SYS AUDIO: ON" else "SYS AUDIO: OFF"
+            binding.systemAudioToggleButton.backgroundTintList = getButtonColorStateList(requireContext(), enabled)
         }
 
         binding.srtlaStatsButton.setOnClickListener {

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -694,6 +694,14 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
         // Request permissions in onResume() instead of onStart() to fix preview freeze
         // when quickly going to settings and back (StreamPack fix 78f1dc28c)
         requestCameraAndMicrophonePermissions()
+
+        // Request MediaProjection once at startup for the audio mix feature
+        if (!previewViewModel.hasRequestedStartupMediaProjection) {
+            previewViewModel.hasRequestedStartupMediaProjection = true
+            previewViewModel.mediaProjectionHelper.requestProjection(mediaProjectionLauncher) { mp ->
+                previewViewModel.onStartupMediaProjectionAcquired(mp)
+            }
+        }
         
         if (PermissionManager.hasPermissions(requireContext(), Manifest.permission.CAMERA)) {
             // FIRST: Restore orientation lock if streaming, BEFORE restarting preview

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -480,10 +480,7 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
                 try {
                     if (level == com.dimadesu.lifestreamer.audio.AudioLevel.SILENT) {
                         binding.audioLevelMeter.reset()
-                        // Hide meter but keep space allocated (INVISIBLE, not GONE)
-                        binding.audioLevelContainer.visibility = android.view.View.INVISIBLE
                     } else {
-                        binding.audioLevelContainer.visibility = android.view.View.VISIBLE
                         binding.audioLevelMeter.setAudioLevel(level)
                     }
                 } catch (t: Throwable) {

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -175,6 +175,14 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
             previewViewModel.toggleAudioDebugOverlay()
         }
 
+        binding.systemAudioToggleButton.setOnClickListener {
+            previewViewModel.toggleSystemAudioForCamera()
+        }
+
+        previewViewModel.useSystemAudioForCameraLiveData.observe(viewLifecycleOwner) { enabled ->
+            binding.systemAudioToggleButton.text = if (enabled) "SYS AUDIO: ON" else "SYS AUDIO: OFF"
+        }
+
         binding.srtlaStatsButton.setOnClickListener {
             previewViewModel.setSrtlaStatsVisible(binding.srtlaStatsScrollView.visibility != View.VISIBLE)
         }

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -968,11 +968,13 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
         isRtmpOrBitmap: Boolean
     ) {
         if (isRtmpOrBitmap) {
+            // RTMP source (live or bitmap fallback) - try MediaProjection, fallback to microphone
+            // Note: BT mic toggle is ignored here - RTMP always uses MediaProjection or system mic
             val projection = streamingMediaProjection ?: mediaProjectionHelper.getMediaProjection()
             if (projection != null && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
                 try {
                     currentStreamer.setAudioSource(MediaProjectionAudioSourceFactory(projection))
-                    Log.i(TAG, "Fallback: Set MediaProjection audio for RTMP/Bitmap video")
+                    Log.i(TAG, "Set MediaProjection audio for RTMP/Bitmap video")
                 } catch (e: Exception) {
                     Log.w(TAG, "MediaProjection audio failed, using conditional source: ${e.message}")
                     currentStreamer.setAudioSource(com.dimadesu.lifestreamer.audio.ConditionalAudioSourceFactory())
@@ -982,6 +984,7 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                 currentStreamer.setAudioSource(com.dimadesu.lifestreamer.audio.ConditionalAudioSourceFactory())
             }
         } else {
+            // Camera source, UVC source, or UVC bitmap fallback — use mic (BT-aware)
             Log.i(TAG, "Camera/UVC video detected, using ConditionalAudioSourceFactory (BT-aware)")
             currentStreamer.setAudioSource(com.dimadesu.lifestreamer.audio.ConditionalAudioSourceFactory())
         }

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -1112,7 +1112,7 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                         try {
                             val videoSource = serviceStreamer?.videoInput?.sourceFlow?.value
                             val isRtmpSource = videoSource is RTMPVideoSource
-                            if (!isRtmpSource) {
+                            if (!isRtmpSource && !_useSystemAudioForCamera) {
                                 val snapshot = svc.isPassthroughRunning.value
                                 _isMonitorAudioOn.postValue(snapshot)
                                 Log.i(TAG, "Service passthrough running snapshot applied to UI: $snapshot")
@@ -1130,9 +1130,11 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                                 }
                                 val videoSource = serviceStreamer?.videoInput?.sourceFlow?.value
                                 val isRtmpSource = videoSource is RTMPVideoSource
-                                if (!isRtmpSource) {
+                                if (!isRtmpSource && !_useSystemAudioForCamera) {
                                     _isMonitorAudioOn.postValue(running)
                                     Log.i(TAG, "Service passthrough running state observed: $running")
+                                } else if (_useSystemAudioForCamera) {
+                                    Log.d(TAG, "Ignoring passthrough state change while SYS AUDIO is active (running=$running)")
                                 } else {
                                     Log.d(TAG, "Ignoring passthrough state change while on RTMP source (running=$running)")
                                 }

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -4206,8 +4206,10 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
     private fun getAudioSourceLabel(audioSource: Any?): String {
         return when {
             audioSource == null -> application.getString(R.string.audio_source_none)
-            audioSource is IMediaProjectionSource -> 
+            audioSource is IMediaProjectionSource ->
                 application.getString(R.string.audio_source_rtmp)
+            audioSource is com.dimadesu.lifestreamer.audio.BluetoothAudioSource ->
+                application.getString(R.string.audio_source_bluetooth)
             else -> application.getString(R.string.audio_source_microphone)
         }
     }

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -580,6 +580,9 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
         viewModelScope.launch {
             setAudioSourceBasedOnVideoSource()
             if (_useSystemAudioForCamera) {
+                // MediaProjectionService.startForeground() replaced CameraStreamerService's
+                // notification. Re-post the regular notification to restore Start/Mute/Quit.
+                try { serviceBinder?.refreshNotification() } catch (_: Throwable) {}
                 // SYS AUDIO on: stop mic passthrough — stream now uses phone audio, not mic
                 if (_isMonitorAudioOn.value == true) {
                     Log.i(TAG, "SYS AUDIO on - stopping mic passthrough (stream uses phone audio)")

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -2578,13 +2578,15 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
         vuMeterEffect = effect
         audioProcessor.add(effect)
 
-        // Watchdog: reset to SILENT if no audio frames arrive for 500ms (e.g. source transitions)
-        vuMeterWatchdogJob?.cancel()
+        // Watchdog: reset to SILENT if no non-silent audio frames arrive for 1500ms.
+        // Resets lastAudioLevelTimeMs after firing so it doesn't repeatedly re-emit
+        // until new non-silent audio arrives — prevents flicker during brief silent gaps.
         vuMeterWatchdogJob = viewModelScope.launch {
             while (true) {
                 delay(200)
                 val lastTime = lastAudioLevelTimeMs
-                if (lastTime > 0 && System.currentTimeMillis() - lastTime > 500) {
+                if (lastTime > 0 && System.currentTimeMillis() - lastTime > 1500) {
+                    lastAudioLevelTimeMs = 0L // Prevent re-firing until new non-silent audio
                     _audioLevelFlow.value = com.dimadesu.lifestreamer.audio.AudioLevel.SILENT
                 }
             }

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -512,28 +512,37 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
     // MediaProjection session for streaming
     private var streamingMediaProjection: MediaProjection? = null
 
-    // MediaProjection acquired once at app startup — kept alive for system audio toggle feature
+    // MediaProjection token held outside of a stream session — acquired on first RTMP/SYS AUDIO use
     private var startupMediaProjection: MediaProjection? = null
-
-    // Whether the startup MP permission has already been requested this session
-    var hasRequestedStartupMediaProjection = false
-
-    fun onStartupMediaProjectionAcquired(mp: MediaProjection?) {
-        if (mp == null) {
-            Log.w(TAG, "Startup MediaProjection permission denied — will use mic only")
-            return
-        }
-        startupMediaProjection = mp
-        Log.i(TAG, "Startup MediaProjection acquired")
-    }
 
     // Toggle: camera/UVC sources use full-phone system audio instead of mic
     private var _useSystemAudioForCamera = false
     val useSystemAudioForCameraLiveData = MutableLiveData(false)
 
-    fun toggleSystemAudioForCamera() {
+    fun toggleSystemAudioForCamera(
+        mediaProjectionLauncher: androidx.activity.result.ActivityResultLauncher<Intent>
+    ) {
+        val alreadyHasProjection = startupMediaProjection != null
+                || streamingMediaProjection != null
+                || mediaProjectionHelper.getMediaProjection() != null
+        if (!alreadyHasProjection && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+            Log.i(TAG, "Requesting MediaProjection for SYS AUDIO toggle")
+            mediaProjectionHelper.requestProjection(mediaProjectionLauncher) { projection ->
+                if (projection == null) {
+                    Log.w(TAG, "MediaProjection denied — SYS AUDIO toggle cancelled")
+                    return@requestProjection
+                }
+                startupMediaProjection = projection
+                doToggleSystemAudioForCamera()
+            }
+        } else {
+            doToggleSystemAudioForCamera()
+        }
+    }
+
+    private fun doToggleSystemAudioForCamera() {
         _useSystemAudioForCamera = !_useSystemAudioForCamera
-        useSystemAudioForCameraLiveData.value = _useSystemAudioForCamera
+        useSystemAudioForCameraLiveData.postValue(_useSystemAudioForCamera)
         Log.i(TAG, "System audio for camera toggled: $_useSystemAudioForCamera")
         viewModelScope.launch { setAudioSourceBasedOnVideoSource() }
     }
@@ -2045,7 +2054,6 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                     streamingMediaProjection?.stop()
                     streamingMediaProjection = null
                     startupMediaProjection = null
-                    hasRequestedStartupMediaProjection = false
                 } finally {
                     // Set status to NOT_STREAMING FIRST so any pending callbacks see it immediately
                     service?.setStreamStatus(StreamStatus.NOT_STREAMING)
@@ -2124,16 +2132,10 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                             Log.w(TAG, "Stream did not stop cleanly after 5 seconds - forcing cleanup")
                         }
                         
-                        // Pause VU meter after stopping an RTMP stream - RTMP audio is gone and
-                        // mic levels would be misleading while RTMP source is still selected.
-                        // The meter resumes when the user switches back to camera/UVC.
-                        val audioSource = currentStreamer.audioInput?.sourceFlow?.value
-                        if (audioSource is IMediaProjectionSource) {
-                            disableAudioLevelMonitoring()
-                            Log.i(TAG, "Paused VU meter after RTMP stream stop (RTMP source still active)")
-                        } else {
-                            Log.i(TAG, "Stream confirmed stopped - audio source is mic, VU meter unchanged")
-                        }
+                        // Restart VU meter after stream stops — audio source remains valid regardless
+                        // of video source since startupMediaProjection is always available.
+                        setupAudioLevelMonitoring()
+                        Log.i(TAG, "Restarted VU meter after stream stop")
 
                         Log.i(TAG, "Stream stop completed successfully")
                         
@@ -3207,13 +3209,6 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                     _activeRtmpIndex.postValue(rtmpIndex)
                     _userToggledUvc.postValue(false)
 
-                    // Pause VU meter when not streaming - RTMP audio isn't available until stream
-                    // starts so mic levels would be misleading. Keep it running during an active
-                    // stream so MediaProjection audio levels continue to display.
-                    if (!isCurrentlyStreaming) {
-                        disableAudioLevelMonitoring()
-                    }
-
                     // Suppress passthrough observer updates during source switch
                     // to prevent monitor toggle from resetting to OFF
                     suppressPassthroughObserver = true
@@ -3236,26 +3231,29 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                     showExposureSlider.value = false
                     showLensDistanceSlider.value = false
 
-                    // Only request MediaProjection when switching to RTMP while streaming.
+                    // Always require MediaProjection when switching to RTMP, regardless of streaming
+                    // state. If startup MP was already acquired, reuse it without prompting.
                     val needProjection = android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q
-                            && isCurrentlyStreaming
+                            && startupMediaProjection == null
                             && streamingMediaProjection == null
                             && mediaProjectionHelper.getMediaProjection() == null
 
                     if (needProjection) {
                         if (mediaProjectionLauncher != null) {
-                            Log.i(TAG, "Requesting MediaProjection permission (audio) while switching video to RTMP during active stream")
+                            Log.i(TAG, "Requesting MediaProjection permission for RTMP source switch")
                             mediaProjectionHelper.requestProjection(mediaProjectionLauncher) { projection ->
                                 Log.i(TAG, "MediaProjection callback received during RTMP switch: ${projection != null}")
                                 viewModelScope.launch {
-                                    streamingMediaProjection = projection
                                     if (projection == null) {
                                         // Permission denied - turn off RTMP toggle (BT toggle stays visible)
                                         _activeRtmpIndex.postValue(null)
                                         _streamerErrorLiveData.postValue("MediaProjection permission denied - staying on camera source")
                                         return@launch
                                     }
-                                    
+                                    // Store as startup MP (not streaming MP — stream hasn't started yet)
+                                    startupMediaProjection = projection
+                                    if (isCurrentlyStreaming) streamingMediaProjection = projection
+
                                     // Permission granted - now hide BT toggle (RTMP uses MediaProjection audio)
                                     _showBluetoothToggle.postValue(false)
 
@@ -3289,10 +3287,6 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                             return@launch
                         }
                     } else {
-                        if (!isCurrentlyStreaming) {
-                            Log.i(TAG, "Not requesting MediaProjection because stream is not active; will request when starting stream if needed")
-                        }
-                        
                         // Hide BT toggle - RTMP uses MediaProjection audio, not microphone
                         _showBluetoothToggle.postValue(false)
 

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -544,7 +544,27 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
         _useSystemAudioForCamera = !_useSystemAudioForCamera
         useSystemAudioForCameraLiveData.postValue(_useSystemAudioForCamera)
         Log.i(TAG, "System audio for camera toggled: $_useSystemAudioForCamera")
-        viewModelScope.launch { setAudioSourceBasedOnVideoSource() }
+        viewModelScope.launch {
+            setAudioSourceBasedOnVideoSource()
+            if (_useSystemAudioForCamera) {
+                // SYS AUDIO on: stop mic passthrough — stream now uses phone audio, not mic
+                if (_isMonitorAudioOn.value == true) {
+                    Log.i(TAG, "SYS AUDIO on - stopping mic passthrough (stream uses phone audio)")
+                    service?.stopAudioPassthrough()
+                }
+            } else {
+                // SYS AUDIO off: restore BT mic if it was enabled (highest priority after SYS AUDIO)
+                if (com.dimadesu.lifestreamer.audio.BluetoothAudioConfig.isEnabled()) {
+                    Log.i(TAG, "SYS AUDIO off - re-applying BT policy to restore BT mic")
+                    try { serviceBinder?.setUseBluetoothMic(true) } catch (_: Throwable) {}
+                }
+                // Restart monitoring if it was on (startAudioPassthrough handles BT internally)
+                if (_isMonitorAudioOn.value == true) {
+                    Log.i(TAG, "SYS AUDIO off - restarting audio monitoring")
+                    applyMonitorAudioState()
+                }
+            }
+        }
     }
 
     // Connection retry mechanism (inspired by Moblin)
@@ -956,11 +976,11 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
 
     /**
      * Determines and sets the appropriate audio source based on the current video source.
-     * Audio follows video:
-     * - Camera video -> Microphone (or BT mic if toggled ON via ConditionalAudioSourceFactory)
-     * - RTMP/Bitmap video -> MediaProjection (if available), otherwise Microphone
-     * 
-     * Note: BT mic toggle only affects Camera sources, not RTMP/Bitmap which use MediaProjection.
+     * Priority for camera/UVC sources: SYS AUDIO (full-phone MP) > BT mic > built-in mic.
+     * RTMP/Bitmap sources always use MediaProjection (app-only), falling back to mic.
+     *
+     * Note: BT mic SCO negotiation is handled separately by BluetoothAudioManager. This method
+     * only switches the factory; callers must re-apply BT policy when transitioning off SYS AUDIO.
      */
     private suspend fun setAudioSourceBasedOnVideoSource() {
         val currentStreamer = serviceStreamer ?: return

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -1772,6 +1772,10 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
             Log.i(TAG, "MediaProjection callback received - mediaProjection: ${if (mediaProjection != null) "SUCCESS" else "NULL"}")
             if (mediaProjection != null) {
                 streamingMediaProjection = mediaProjection
+                // The startup MP was invalidated when requestProjection() called release() to start
+                // a fresh service. Sync startupMediaProjection to the new valid token so SYS AUDIO
+                // continues to work if/when this stream ends and the user returns to camera.
+                startupMediaProjection = mediaProjection
                 Log.i(TAG, "MediaProjection acquired for streaming session - starting setup...")
 
                 viewModelScope.launch {
@@ -2012,12 +2016,12 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
 
                     Log.i(TAG, "Stopping stream...")
 
-                    // Release MediaProjection FIRST to interrupt any ongoing capture
-                    streamingMediaProjection?.let { mediaProjection ->
-                        mediaProjection.stop()
-                        Log.i(TAG, "MediaProjection stopped")
-                    }
+                    // Keep the MediaProjection token alive after stream stops — it is transferred to
+                    // startupMediaProjection so SYS AUDIO and future streams can reuse it without
+                    // requiring a new permission dialog.
+                    startupMediaProjection = streamingMediaProjection
                     streamingMediaProjection = null
+                    Log.i(TAG, "MediaProjection transferred to startupMediaProjection after stream stop")
 
                     // Stop streaming via helper method
                     try {
@@ -2037,9 +2041,11 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
 
                 } catch (e: Throwable) {
                     Log.e(TAG, "stopStream failed", e)
-                    // Force clear state
+                    // Force clear state — on error, stop everything and allow re-acquisition
                     streamingMediaProjection?.stop()
                     streamingMediaProjection = null
+                    startupMediaProjection = null
+                    hasRequestedStartupMediaProjection = false
                 } finally {
                     // Set status to NOT_STREAMING FIRST so any pending callbacks see it immediately
                     service?.setStreamStatus(StreamStatus.NOT_STREAMING)
@@ -2110,9 +2116,9 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                             Log.e(TAG, "CRITICAL: Failed to close endpoint - second start will fail!", e)
                         }
                         
-                        // Clear MediaProjection from service to prevent reusing expired tokens
-                        mediaProjectionHelper.clearMediaProjection()
-                        Log.i(TAG, "MediaProjection cleared from service")
+                        // Do not clear MediaProjection from the service on stream stop — the token
+                        // is transferred to startupMediaProjection and can be reused for SYS AUDIO
+                        // or the next stream without a new permission dialog.
                         
                         if (currentStreamer.isStreamingFlow.value == true) {
                             Log.w(TAG, "Stream did not stop cleanly after 5 seconds - forcing cleanup")

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -2559,10 +2559,20 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
         
         // Remove any previous effect
         vuMeterEffect?.let { audioProcessor.remove(it) }
+        vuMeterWatchdogJob?.cancel()
+        vuMeterWatchdogJob = null
+        lastAudioLevelTimeMs = 0L
         
         // Create new VuMeterEffect using IConsumerAudioEffect plugin (runs on background coroutine)
         val effect = com.dimadesu.lifestreamer.audio.VuMeterEffect { levels ->
-            lastAudioLevelTimeMs = System.currentTimeMillis()
+            // Only stamp time on non-silent frames so the watchdog can detect both:
+            // (a) no frames arriving (source transitions) and
+            // (b) frames arriving with zero amplitude (e.g. MediaProjection when nothing plays)
+            val isEffectivelySilent = levels.rms < 0.0001f && levels.peak < 0.0001f
+                    && levels.rmsRight < 0.0001f && levels.peakRight < 0.0001f
+            if (!isEffectivelySilent) {
+                lastAudioLevelTimeMs = System.currentTimeMillis()
+            }
             _audioLevelFlow.value = levels
         }
         vuMeterEffect = effect

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -3437,6 +3437,11 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                     }
                     setAudioSourceBasedOnVideoSource()
 
+                    // Re-activate BT mic SCO if toggle is on (SCO was stopped while on RTMP source)
+                    if (_useBluetoothMic.value == true && !_useSystemAudioForCamera) {
+                        service?.triggerBluetoothMicActivation()
+                    }
+
                     // Resume VU meter now that the audio source is restored
                     setupAudioLevelMonitoring()
 

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -409,7 +409,11 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
             // Switch source away from MP first; service would defer BT if MP is still active.
             viewModelScope.launch {
                 setAudioSourceBasedOnVideoSource()
-                try { serviceBinder?.setUseBluetoothMic(true) } catch (_: Throwable) {}
+                // Force passthrough restart if monitoring was on — passthrough was stopped
+                // when SYS AUDIO turned on, so _isPassthroughRunning is false, but we want
+                // the integrated BT passthrough restart to re-enable monitoring with BT mic.
+                val monitorWasOn = _isMonitorAudioOn.value == true
+                try { serviceBinder?.setUseBluetoothMic(true, forcePassthroughRestart = monitorWasOn) } catch (_: Throwable) {}
             }
         } else {
             // If we have a direct binder, call it. Otherwise rely on the config being applied
@@ -565,7 +569,12 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
         // Mutual exclusivity: enabling SYS AUDIO turns off BT mic
         if (_useSystemAudioForCamera && _useBluetoothMic.value == true) {
             Log.i(TAG, "SYS AUDIO on - turning off BT mic (mutual exclusivity)")
-            setUseBluetoothMic(false)
+            _useBluetoothMic.postValue(false)
+            try { com.dimadesu.lifestreamer.audio.BluetoothAudioConfig.setEnabled(false) } catch (_: Throwable) {}
+            // skipPassthroughRestart=true: SYS AUDIO will stop/manage passthrough itself;
+            // without this flag the service would restart passthrough with built-in mic just
+            // before setAudioSourceBasedOnVideoSource switches the stream to MediaProjection.
+            try { serviceBinder?.setUseBluetoothMic(false, skipPassthroughRestart = true) } catch (_: Throwable) {}
         }
 
         viewModelScope.launch {

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -3355,8 +3355,9 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                     rtmpDisconnectListener = null
                     currentRtmpPlayer = null
 
-                    // Don't release streaming MediaProjection here - it's managed by stream lifecycle
-                    if (streamingMediaProjection == null) {
+                    // Don't release streaming MediaProjection here - it's managed by stream lifecycle.
+                    // Also keep the service alive if startupMediaProjection is still in use.
+                    if (streamingMediaProjection == null && startupMediaProjection == null) {
                         mediaProjectionHelper.release()
                     }
 
@@ -3376,9 +3377,9 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                         currentStreamer.setVideoSource(CameraSourceFactory(application))
                         Log.i(TAG, "Switched to camera video (default camera) with BT-aware audio")
                     }
-                    currentStreamer.setAudioSource(com.dimadesu.lifestreamer.audio.ConditionalAudioSourceFactory())
+                    setAudioSourceBasedOnVideoSource()
 
-                    // Resume VU meter now that mic is the audio source again
+                    // Resume VU meter now that the audio source is restored
                     setupAudioLevelMonitoring()
 
                     // Re-add bitrate regulator if streaming with SRT

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -2542,7 +2542,9 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
     private var audioConfigObserverJob: kotlinx.coroutines.Job? = null
     private var startCaptureJob: kotlinx.coroutines.Job? = null
     private var stopCaptureJob: kotlinx.coroutines.Job? = null
+    private var vuMeterWatchdogJob: kotlinx.coroutines.Job? = null
     private var vuMeterEffect: com.dimadesu.lifestreamer.audio.VuMeterEffect? = null
+    @Volatile private var lastAudioLevelTimeMs = 0L
     
     /**
      * Set up audio level monitoring on the streamer's audio processor.
@@ -2560,10 +2562,23 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
         
         // Create new VuMeterEffect using IConsumerAudioEffect plugin (runs on background coroutine)
         val effect = com.dimadesu.lifestreamer.audio.VuMeterEffect { levels ->
+            lastAudioLevelTimeMs = System.currentTimeMillis()
             _audioLevelFlow.value = levels
         }
         vuMeterEffect = effect
         audioProcessor.add(effect)
+
+        // Watchdog: reset to SILENT if no audio frames arrive for 500ms (e.g. source transitions)
+        vuMeterWatchdogJob?.cancel()
+        vuMeterWatchdogJob = viewModelScope.launch {
+            while (true) {
+                delay(200)
+                val lastTime = lastAudioLevelTimeMs
+                if (lastTime > 0 && System.currentTimeMillis() - lastTime > 500) {
+                    _audioLevelFlow.value = com.dimadesu.lifestreamer.audio.AudioLevel.SILENT
+                }
+            }
+        }
         
         // Observe the streamer's audioConfigFlow for channel count changes
         audioConfigObserverJob?.cancel()
@@ -2610,6 +2625,9 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
             audioConfigObserverJob = null
             startCaptureJob?.cancel()
             startCaptureJob = null
+            vuMeterWatchdogJob?.cancel()
+            vuMeterWatchdogJob = null
+            lastAudioLevelTimeMs = 0L
             vuMeterEffect?.let { effect ->
                 serviceStreamer?.audioInput?.processor?.remove(effect)
                 effect.close()

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -392,16 +392,33 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
             }
         }
         
+        // Mutual exclusivity: enabling BT mic turns off SYS AUDIO
+        val sysAudioWasOn = enabled && _useSystemAudioForCamera
+        if (sysAudioWasOn) {
+            Log.i(TAG, "BT mic on - turning off SYS AUDIO (mutual exclusivity)")
+            _useSystemAudioForCamera = false
+            useSystemAudioForCameraLiveData.postValue(false)
+        }
+
         _useBluetoothMic.postValue(enabled)
         try {
             com.dimadesu.lifestreamer.audio.BluetoothAudioConfig.setEnabled(enabled)
         } catch (_: Throwable) {}
-        // If we have a direct binder, call it. Otherwise rely on the config being applied
-        // The service will handle restarting passthrough if monitoring is active
-        try {
-            serviceBinder?.setUseBluetoothMic(enabled)
-        } catch (_: Throwable) {
-            // Best-effort only: nothing to do if binder isn't available
+
+        if (sysAudioWasOn) {
+            // Switch source away from MP first; service would defer BT if MP is still active.
+            viewModelScope.launch {
+                setAudioSourceBasedOnVideoSource()
+                try { serviceBinder?.setUseBluetoothMic(true) } catch (_: Throwable) {}
+            }
+        } else {
+            // If we have a direct binder, call it. Otherwise rely on the config being applied
+            // The service will handle restarting passthrough if monitoring is active
+            try {
+                serviceBinder?.setUseBluetoothMic(enabled)
+            } catch (_: Throwable) {
+                // Best-effort only: nothing to do if binder isn't available
+            }
         }
     }
 
@@ -544,6 +561,13 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
         _useSystemAudioForCamera = !_useSystemAudioForCamera
         useSystemAudioForCameraLiveData.postValue(_useSystemAudioForCamera)
         Log.i(TAG, "System audio for camera toggled: $_useSystemAudioForCamera")
+
+        // Mutual exclusivity: enabling SYS AUDIO turns off BT mic
+        if (_useSystemAudioForCamera && _useBluetoothMic.value == true) {
+            Log.i(TAG, "SYS AUDIO on - turning off BT mic (mutual exclusivity)")
+            setUseBluetoothMic(false)
+        }
+
         viewModelScope.launch {
             setAudioSourceBasedOnVideoSource()
             if (_useSystemAudioForCamera) {

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -4483,13 +4483,22 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                 // Save audio source type to DataStore for persistence
                 storageRepository.saveAudioSourceType(sourceType)
                 Log.d(TAG, "Saved audio source type to DataStore")
+
+                // Only switch to built-in mic if BT mic and SYS AUDIO are both inactive.
+                // When BT or MP is active, the preference is saved and will apply next time
+                // ConditionalAudioSourceFactory is used (e.g. after SYS AUDIO is toggled off).
+                val btActive = _useBluetoothMic.value == true
+                val sysAudioActive = _useSystemAudioForCamera
+                if (btActive || sysAudioActive) {
+                    Log.i(TAG, "Audio source preference saved but not applied — " +
+                            "BT=$btActive, SYS=$sysAudioActive override is active")
+                } else {
+                    currentStreamer.setAudioSource(ConditionalAudioSourceFactory())
+                    Log.i(TAG, "Audio source changed to: ${getAudioSourceName(sourceType)}")
+                }
                 
-                // Use ConditionalAudioSourceFactory which reads from DataStore and disables effects
-                currentStreamer.setAudioSource(ConditionalAudioSourceFactory())
-                Log.i(TAG, "Audio source changed to: ${getAudioSourceName(sourceType)}")
-                
-                // If audio monitoring is enabled, restart passthrough with new settings
-                if (_isMonitorAudioOn.value == true) {
+                // If audio monitoring is enabled and we actually switched the source, restart passthrough
+                if (!btActive && !sysAudioActive && _isMonitorAudioOn.value == true) {
                     Log.i(TAG, "Restarting audio passthrough with new settings")
                     service?.stopAudioPassthrough()
                     delay(100) // Small delay to ensure clean restart

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -512,6 +512,21 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
     // MediaProjection session for streaming
     private var streamingMediaProjection: MediaProjection? = null
 
+    // MediaProjection acquired once at app startup for the audio mix feature
+    private var startupMediaProjection: MediaProjection? = null
+
+    // Whether the startup MP permission has already been requested this session
+    var hasRequestedStartupMediaProjection = false
+
+    fun onStartupMediaProjectionAcquired(mp: MediaProjection?) {
+        if (mp == null) {
+            Log.w(TAG, "Startup MediaProjection permission denied — will use mic only")
+            return
+        }
+        startupMediaProjection = mp
+        Log.i(TAG, "Startup MediaProjection acquired — audio mix feature ready")
+    }
+
     // Connection retry mechanism (inspired by Moblin)
     private val reconnectTimer = ReconnectTimer()
     
@@ -933,15 +948,31 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
         // UVC bitmap fallback keeps mic audio — only RTMP (live or its bitmap fallback) uses MediaProjection.
         val isUvcBitmapFallback = currentVideoSource is IBitmapSource && (_userToggledUvc.value == true)
         val isRtmpOrBitmap = currentVideoSource != null && currentVideoSource !is ICameraSource && !isUvcBitmapFallback
-        
+
+        val mixProjection = startupMediaProjection ?: streamingMediaProjection ?: mediaProjectionHelper.getMediaProjection()
+        if (mixProjection != null && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+            try {
+                currentStreamer.setAudioSource(MediaProjectionAudioSourceFactory(mixProjection, captureFullPhone = true))
+                Log.i(TAG, "Set full-phone system audio source")
+            } catch (e: Exception) {
+                Log.w(TAG, "Full-phone audio failed, falling back: ${e.message}")
+                setFallbackAudioSource(currentStreamer, isRtmpOrBitmap)
+            }
+        } else {
+            setFallbackAudioSource(currentStreamer, isRtmpOrBitmap)
+        }
+    }
+
+    private suspend fun setFallbackAudioSource(
+        currentStreamer: SingleStreamer,
+        isRtmpOrBitmap: Boolean
+    ) {
         if (isRtmpOrBitmap) {
-            // RTMP source (live or bitmap fallback) - try MediaProjection, fallback to microphone
-            // Note: BT mic toggle is ignored here - RTMP always uses MediaProjection or system mic
             val projection = streamingMediaProjection ?: mediaProjectionHelper.getMediaProjection()
             if (projection != null && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
                 try {
                     currentStreamer.setAudioSource(MediaProjectionAudioSourceFactory(projection))
-                    Log.i(TAG, "Set MediaProjection audio for RTMP/Bitmap video")
+                    Log.i(TAG, "Fallback: Set MediaProjection audio for RTMP/Bitmap video")
                 } catch (e: Exception) {
                     Log.w(TAG, "MediaProjection audio failed, using conditional source: ${e.message}")
                     currentStreamer.setAudioSource(com.dimadesu.lifestreamer.audio.ConditionalAudioSourceFactory())
@@ -951,7 +982,6 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                 currentStreamer.setAudioSource(com.dimadesu.lifestreamer.audio.ConditionalAudioSourceFactory())
             }
         } else {
-            // Camera source, UVC source, or UVC bitmap fallback — use mic (BT-aware)
             Log.i(TAG, "Camera/UVC video detected, using ConditionalAudioSourceFactory (BT-aware)")
             currentStreamer.setAudioSource(com.dimadesu.lifestreamer.audio.ConditionalAudioSourceFactory())
         }
@@ -2069,9 +2099,12 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                             Log.e(TAG, "CRITICAL: Failed to close endpoint - second start will fail!", e)
                         }
                         
-                        // Clear MediaProjection from service to prevent reusing expired tokens
+                        // Clear MediaProjection from service to prevent reusing expired tokens.
+                        // Also reset startup MP so onResume requests a fresh one for the next stream.
                         mediaProjectionHelper.clearMediaProjection()
-                        Log.i(TAG, "MediaProjection cleared from service")
+                        startupMediaProjection = null
+                        hasRequestedStartupMediaProjection = false
+                        Log.i(TAG, "MediaProjection cleared from service — startup MP invalidated, will re-request on resume")
                         
                         if (currentStreamer.isStreamingFlow.value == true) {
                             Log.w(TAG, "Stream did not stop cleanly after 5 seconds - forcing cleanup")
@@ -4187,6 +4220,8 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
         // Clean up MediaProjection resources
         streamingMediaProjection?.stop()
         streamingMediaProjection = null
+        startupMediaProjection?.stop()
+        startupMediaProjection = null
         mediaProjectionHelper.release()
         Log.i(TAG, "PreviewViewModel cleared but service continues running for background streaming")
     }

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -512,7 +512,7 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
     // MediaProjection session for streaming
     private var streamingMediaProjection: MediaProjection? = null
 
-    // MediaProjection acquired once at app startup for the audio mix feature
+    // MediaProjection acquired once at app startup — kept alive for system audio toggle feature
     private var startupMediaProjection: MediaProjection? = null
 
     // Whether the startup MP permission has already been requested this session
@@ -524,7 +524,18 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
             return
         }
         startupMediaProjection = mp
-        Log.i(TAG, "Startup MediaProjection acquired — audio mix feature ready")
+        Log.i(TAG, "Startup MediaProjection acquired")
+    }
+
+    // Toggle: camera/UVC sources use full-phone system audio instead of mic
+    private var _useSystemAudioForCamera = false
+    val useSystemAudioForCameraLiveData = MutableLiveData(false)
+
+    fun toggleSystemAudioForCamera() {
+        _useSystemAudioForCamera = !_useSystemAudioForCamera
+        useSystemAudioForCameraLiveData.value = _useSystemAudioForCamera
+        Log.i(TAG, "System audio for camera toggled: $_useSystemAudioForCamera")
+        viewModelScope.launch { setAudioSourceBasedOnVideoSource() }
     }
 
     // Connection retry mechanism (inspired by Moblin)
@@ -949,24 +960,6 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
         val isUvcBitmapFallback = currentVideoSource is IBitmapSource && (_userToggledUvc.value == true)
         val isRtmpOrBitmap = currentVideoSource != null && currentVideoSource !is ICameraSource && !isUvcBitmapFallback
 
-        val mixProjection = startupMediaProjection ?: streamingMediaProjection ?: mediaProjectionHelper.getMediaProjection()
-        if (mixProjection != null && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
-            try {
-                currentStreamer.setAudioSource(MediaProjectionAudioSourceFactory(mixProjection, captureFullPhone = true))
-                Log.i(TAG, "Set full-phone system audio source")
-            } catch (e: Exception) {
-                Log.w(TAG, "Full-phone audio failed, falling back: ${e.message}")
-                setFallbackAudioSource(currentStreamer, isRtmpOrBitmap)
-            }
-        } else {
-            setFallbackAudioSource(currentStreamer, isRtmpOrBitmap)
-        }
-    }
-
-    private suspend fun setFallbackAudioSource(
-        currentStreamer: SingleStreamer,
-        isRtmpOrBitmap: Boolean
-    ) {
         if (isRtmpOrBitmap) {
             // RTMP source (live or bitmap fallback) - try MediaProjection, fallback to microphone
             // Note: BT mic toggle is ignored here - RTMP always uses MediaProjection or system mic
@@ -981,6 +974,21 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                 }
             } else {
                 Log.i(TAG, "No MediaProjection available for RTMP/Bitmap, using conditional source")
+                currentStreamer.setAudioSource(com.dimadesu.lifestreamer.audio.ConditionalAudioSourceFactory())
+            }
+        } else if (_useSystemAudioForCamera && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+            // Camera/UVC with system audio toggle ON — capture full phone audio output
+            val projection = startupMediaProjection ?: streamingMediaProjection ?: mediaProjectionHelper.getMediaProjection()
+            if (projection != null) {
+                try {
+                    currentStreamer.setAudioSource(MediaProjectionAudioSourceFactory(projection, captureFullPhone = true))
+                    Log.i(TAG, "Set full-phone system audio for camera/UVC source")
+                } catch (e: Exception) {
+                    Log.w(TAG, "Full-phone audio failed, falling back to mic: ${e.message}")
+                    currentStreamer.setAudioSource(com.dimadesu.lifestreamer.audio.ConditionalAudioSourceFactory())
+                }
+            } else {
+                Log.w(TAG, "No MediaProjection for system audio toggle, using mic")
                 currentStreamer.setAudioSource(com.dimadesu.lifestreamer.audio.ConditionalAudioSourceFactory())
             }
         } else {
@@ -2102,12 +2110,9 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                             Log.e(TAG, "CRITICAL: Failed to close endpoint - second start will fail!", e)
                         }
                         
-                        // Clear MediaProjection from service to prevent reusing expired tokens.
-                        // Also reset startup MP so onResume requests a fresh one for the next stream.
+                        // Clear MediaProjection from service to prevent reusing expired tokens
                         mediaProjectionHelper.clearMediaProjection()
-                        startupMediaProjection = null
-                        hasRequestedStartupMediaProjection = false
-                        Log.i(TAG, "MediaProjection cleared from service — startup MP invalidated, will re-request on resume")
+                        Log.i(TAG, "MediaProjection cleared from service")
                         
                         if (currentStreamer.isStreamingFlow.value == true) {
                             Log.w(TAG, "Stream did not stop cleanly after 5 seconds - forcing cleanup")

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -987,7 +987,7 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
         val currentVideoSource = currentStreamer.videoInput?.sourceFlow?.value
         // UVC bitmap fallback keeps mic audio — only RTMP (live or its bitmap fallback) uses MediaProjection.
         val isUvcBitmapFallback = currentVideoSource is IBitmapSource && (_userToggledUvc.value == true)
-        val isRtmpOrBitmap = currentVideoSource != null && currentVideoSource !is ICameraSource && !isUvcBitmapFallback
+        val isRtmpOrBitmap = currentVideoSource is RTMPVideoSource || (currentVideoSource is IBitmapSource && !isUvcBitmapFallback)
 
         if (isRtmpOrBitmap) {
             // RTMP source (live or bitmap fallback) - try MediaProjection, fallback to microphone

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/RtmpSourceSwitchHelper.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/RtmpSourceSwitchHelper.kt
@@ -286,12 +286,12 @@ internal object RtmpSourceSwitchHelper {
                             // Switch video source
                             currentStreamer.setVideoSource(RTMPVideoSource.Factory(exoPlayerInstance))
                             
-                            // Switch audio source immediately after video
-                            // Set audio source: prefer MediaProjection if streaming, otherwise microphone
-                            val isStreaming = currentStreamer.isStreamingFlow.value == true
+                            // Switch audio source immediately after video.
+                            // Use MediaProjection whenever it's available (streaming or not), since
+                            // startupMediaProjection is now acquired when the user toggles RTMP source.
                             val projection = streamingMediaProjection ?: mediaProjectionHelper.getMediaProjection()
-                            
-                            if (isStreaming && projection != null && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+
+                            if (projection != null && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
                                 // Always recreate MediaProjection audio when switching to RTMP.
                                 // After ExoPlayer replacement, Android's AudioPlaybackCapture routing
                                 // may not update for an existing AudioRecord, causing silent audio.
@@ -308,40 +308,12 @@ internal object RtmpSourceSwitchHelper {
                                     }
                                 }
                             } else {
-                                // Use conditional source when not streaming or MediaProjection unavailable
+                                // No MediaProjection available — fall back to mic
                                 try {
                                     currentStreamer.setAudioSource(com.dimadesu.lifestreamer.audio.ConditionalAudioSourceFactory())
+                                    Log.i(TAG, "No MediaProjection available for RTMP, using microphone")
                                 } catch (ae: Exception) {
                                     Log.w(TAG, "Failed to set conditional audio source: ${ae.message}")
-                                }
-                                
-                                // Launch background task to upgrade to MediaProjection if streaming starts
-                                if (!isStreaming && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
-                                    CoroutineScope(Dispatchers.Default).launch {
-                                        try {
-                                            val deadline = System.currentTimeMillis() + 10_000L
-                                            var upgradedProjection = projection ?: mediaProjectionHelper.getMediaProjection()
-                                            if (upgradedProjection == null) {
-                                                while (System.currentTimeMillis() < deadline) {
-                                                    delay(500L)
-                                                    upgradedProjection = mediaProjectionHelper.getMediaProjection()
-                                                    if (upgradedProjection != null) break
-                                                }
-                                            }
-                                            upgradedProjection?.let { mp ->
-                                                if (currentStreamer.isStreamingFlow.value == true) {
-                                                    try {
-                                                        currentStreamer.setAudioSource(MediaProjectionAudioSourceFactory(mp))
-                                                        Log.d(TAG, "Upgraded to MediaProjection audio")
-                                                    } catch (upgradeEx: Exception) {
-                                                        Log.w(TAG, "MediaProjection upgrade failed: ${upgradeEx.message}")
-                                                    }
-                                                }
-                                            }
-                                        } catch (bgEx: Exception) {
-                                            Log.w(TAG, "Background MediaProjection upgrade failed: ${bgEx.message}")
-                                        }
-                                    }
                                 }
                             }
                             

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/RtmpSourceSwitchHelper.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/RtmpSourceSwitchHelper.kt
@@ -94,20 +94,20 @@ internal object RtmpSourceSwitchHelper {
                         override fun onPlaybackStateChanged(playbackState: Int) {
                             if (playbackState == androidx.media3.common.Player.STATE_READY) {
                                 try { player.removeListener(this) } catch (_: Exception) {}
-                                if (cont.isActive) cont.resume(true)
+                                if (cont.isActive) cont.resumeWith(Result.success(true))
                             }
                         }
 
                         override fun onPlayerError(error: androidx.media3.common.PlaybackException) {
                             try { player.removeListener(this) } catch (_: Exception) {}
-                            if (cont.isActive) cont.resume(false)
+                            if (cont.isActive) cont.resumeWith(Result.success(false))
                         }
                     }
                     // If the player is already ready, avoid registering the listener which
                     // could miss the READY event if it happened before listener registration.
                     val currentState = try { player.playbackState } catch (_: Exception) { -1 }
                     if (currentState == androidx.media3.common.Player.STATE_READY) {
-                        if (cont.isActive) cont.resume(true) {}
+                        if (cont.isActive) cont.resumeWith(Result.success(true))
                         return@suspendCancellableCoroutine
                     }
                     player.addListener(listener)

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/RtmpSourceSwitchHelper.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/RtmpSourceSwitchHelper.kt
@@ -94,13 +94,13 @@ internal object RtmpSourceSwitchHelper {
                         override fun onPlaybackStateChanged(playbackState: Int) {
                             if (playbackState == androidx.media3.common.Player.STATE_READY) {
                                 try { player.removeListener(this) } catch (_: Exception) {}
-                                if (cont.isActive) cont.resume(true) {}
+                                if (cont.isActive) cont.resume(true)
                             }
                         }
 
                         override fun onPlayerError(error: androidx.media3.common.PlaybackException) {
                             try { player.removeListener(this) } catch (_: Exception) {}
-                            if (cont.isActive) cont.resume(false) {}
+                            if (cont.isActive) cont.resume(false)
                         }
                     }
                     // If the player is already ready, avoid registering the listener which

--- a/app/src/main/res/layout/main_fragment.xml
+++ b/app/src/main/res/layout/main_fragment.xml
@@ -384,6 +384,22 @@
 
         </LinearLayout>
 
+        <!-- System audio toggle: visible for camera/UVC sources only -->
+        <Button
+            android:id="@+id/systemAudioToggleButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="SYS AUDIO: OFF"
+            android:textSize="10sp"
+            android:paddingVertical="2dp"
+            android:backgroundTint="#80000000"
+            android:textColor="@android:color/white"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            app:goneUnless="@{!viewmodel.isRtmpSource}"
+            app:layout_constraintTop_toBottomOf="@+id/audioLevelContainer"
+            app:layout_constraintStart_toStartOf="@+id/audioLevelContainer"
+            app:layout_constraintEnd_toEndOf="@+id/audioLevelContainer" />
+
         <ScrollView
             android:id="@+id/srtlaStatsScrollView"
             android:layout_width="0dp"

--- a/app/src/main/res/layout/main_fragment.xml
+++ b/app/src/main/res/layout/main_fragment.xml
@@ -254,6 +254,14 @@
                     android:visibility="@{viewmodel.showBluetoothToggle ? android.view.View.VISIBLE : android.view.View.GONE}" />
 
                 <Button
+                    android:id="@+id/systemAudioToggleButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="SYS AUDIO"
+                    android:backgroundTint="@color/button_gray"
+                    app:goneUnless="@{!viewmodel.isRtmpSource}" />
+
+                <Button
                     android:id="@+id/audioDebugToggleButton"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -383,22 +391,6 @@
                 android:layout_height="14dp" />
 
         </LinearLayout>
-
-        <!-- System audio toggle: visible for camera/UVC sources only -->
-        <Button
-            android:id="@+id/systemAudioToggleButton"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:text="SYS AUDIO: OFF"
-            android:textSize="10sp"
-            android:paddingVertical="2dp"
-            android:backgroundTint="#80000000"
-            android:textColor="@android:color/white"
-            style="@style/Widget.MaterialComponents.Button.TextButton"
-            app:goneUnless="@{!viewmodel.isRtmpSource}"
-            app:layout_constraintTop_toBottomOf="@+id/audioLevelContainer"
-            app:layout_constraintStart_toStartOf="@+id/audioLevelContainer"
-            app:layout_constraintEnd_toEndOf="@+id/audioLevelContainer" />
 
         <ScrollView
             android:id="@+id/srtlaStatsScrollView"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,6 +26,7 @@
 
     <!-- Audio source labels -->
     <string name="audio_source_microphone">Microphone</string>
+    <string name="audio_source_bluetooth">Bluetooth</string>
     <string name="audio_source_rtmp">Media Projection Audio</string>
     <string name="audio_source_none">No Audio</string>
 


### PR DESCRIPTION
Major features / highlights:
- [x] Add SYS AUDIO button. Toggling it on asks for Media Projection permission. It will record the whole device audio output.
- [x] RTMP/SRT source shares MP token, but still records only RTMP/SRT player audio, not the whole audio output.
- [x] Always request Media Projection permission when switching to RTMP/SRT source. Before it was allowed to switch before the stream w/o it.

Figure out how it works with:
- [x] Bluetooth mic toggle
  - [x] Don't allow to have both BT and SYS AUDIO on at the same time.
  - [x] Top right corner should show Bluetooth too. Maybe should work same as audio source.
  - [x] With BT toggle on navigate to RTMP SRC and back. BT toggle stays on, but audio input switches to built-in mic.
- [x] Audio monitoring toggle
  - [x] BT monitoring - a little glitchy. Sometimes (when not streaming?) toggling monitoring on/off changes BT mic to built-in, but BT toggle is still on.
- [x] USB source
- [x] AUDIO SRC. Fix when changing "audio sources" it always switches back to built-in mic

Medium priority:
- [x] Always show VU meters (audio monitoring levels UI). Before it was hidden for RTMP/SRT source before stream start, because audio data wasn't available.
- [x] Fix: Before stream start if Media Projection was requested app notification shows notification that doesn't have Start/Mute/Quit buttons.
  - It shows:
    - Audio Capture Active
    - Capturing ExoPlayer audio for streaming
- [ ] Add explanation popup before asking MP permission.
- [ ] Add setting to hide SYS AUDIO button as it's a little exotic feature, not everyone needs it.

Low priority:
- [ ] SYS AUDIO - needs a better name.
- [ ] Fix: Sometimes it makes extra permission requests.

Out of scope / bonus:
- [x] Reset VU meters UI when audio data is not flowing.