### PR TITLE
SYS AUDIO/AUDIO OUT feature polish

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -80,7 +80,11 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
     private lateinit var mediaProjectionLauncher: ActivityResultLauncher<Intent>
     // BLUETOOTH_CONNECT permission launcher
     private lateinit var bluetoothConnectLauncher: ActivityResultLauncher<String>
-    // UI messages from service (notification-start feedback)
+
+    // Track whether each explanation dialog has been shown this session.
+    // Independent flags so both dialogs are shown regardless of MP grant order.
+    private var rtmpAudioExplanationShown = false
+    private var sysAudioExplanationShown = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -177,7 +181,8 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
 
         binding.systemAudioToggleButton.setOnClickListener {
             val isTurningOn = previewViewModel.useSystemAudioForCameraLiveData.value != true
-            if (isTurningOn && !previewViewModel.hasMediaProjection()) {
+            if (isTurningOn && !sysAudioExplanationShown) {
+                sysAudioExplanationShown = true
                 androidx.appcompat.app.AlertDialog.Builder(requireContext())
                     .setTitle(R.string.audio_out_explanation_title)
                     .setMessage(R.string.audio_out_explanation_message)
@@ -185,7 +190,9 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
                         dialog.dismiss()
                         previewViewModel.toggleSystemAudioForCamera(mediaProjectionLauncher)
                     }
-                    .setNegativeButton(android.R.string.cancel, null)
+                    .setNegativeButton(android.R.string.cancel) { _, _ ->
+                        sysAudioExplanationShown = false // reset so it shows again if user cancelled
+                    }
                     .show()
             } else {
                 previewViewModel.toggleSystemAudioForCamera(mediaProjectionLauncher)
@@ -1131,7 +1138,8 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
      */
     private fun toggleVideoSourceWithExplanation(rtmpIndex: Int) {
         val isSwitchingTo = previewViewModel.activeRtmpIndex.value != rtmpIndex
-        if (isSwitchingTo && !previewViewModel.hasMediaProjection()) {
+        if (isSwitchingTo && !rtmpAudioExplanationShown) {
+            rtmpAudioExplanationShown = true
             androidx.appcompat.app.AlertDialog.Builder(requireContext())
                 .setTitle(R.string.rtmp_audio_explanation_title)
                 .setMessage(R.string.rtmp_audio_explanation_message)
@@ -1139,7 +1147,9 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
                     dialog.dismiss()
                     previewViewModel.toggleVideoSource(mediaProjectionLauncher, rtmpIndex = rtmpIndex)
                 }
-                .setNegativeButton(android.R.string.cancel, null)
+                .setNegativeButton(android.R.string.cancel) { _, _ ->
+                    rtmpAudioExplanationShown = false // reset so it shows again if user cancelled
+                }
                 .show()
         } else {
             previewViewModel.toggleVideoSource(mediaProjectionLauncher, rtmpIndex = rtmpIndex)

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -176,7 +176,20 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
         }
 
         binding.systemAudioToggleButton.setOnClickListener {
-            previewViewModel.toggleSystemAudioForCamera(mediaProjectionLauncher)
+            val isTurningOn = previewViewModel.useSystemAudioForCameraLiveData.value != true
+            if (isTurningOn && !previewViewModel.hasMediaProjection()) {
+                androidx.appcompat.app.AlertDialog.Builder(requireContext())
+                    .setTitle(R.string.audio_out_explanation_title)
+                    .setMessage(R.string.audio_out_explanation_message)
+                    .setPositiveButton(R.string.continue_button) { dialog, _ ->
+                        dialog.dismiss()
+                        previewViewModel.toggleSystemAudioForCamera(mediaProjectionLauncher)
+                    }
+                    .setNegativeButton(android.R.string.cancel, null)
+                    .show()
+            } else {
+                previewViewModel.toggleSystemAudioForCamera(mediaProjectionLauncher)
+            }
         }
 
         previewViewModel.useSystemAudioForCameraLiveData.observe(viewLifecycleOwner) { enabled ->

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -145,7 +145,7 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
         }
 
         binding.switchSourceButton.setOnClickListener {
-            previewViewModel.toggleVideoSource(mediaProjectionLauncher, rtmpIndex = 1)
+            toggleVideoSourceWithExplanation(rtmpIndex = 1)
         }
 
         binding.rtmpSrvrButton.setOnClickListener {
@@ -1126,6 +1126,27 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
     }
 
     /**
+     * Toggle RTMP video source, showing an explanation dialog before requesting
+     * MediaProjection permission when the user is switching to RTMP for the first time.
+     */
+    private fun toggleVideoSourceWithExplanation(rtmpIndex: Int) {
+        val isSwitchingTo = previewViewModel.activeRtmpIndex.value != rtmpIndex
+        if (isSwitchingTo && !previewViewModel.hasMediaProjection()) {
+            androidx.appcompat.app.AlertDialog.Builder(requireContext())
+                .setTitle(R.string.rtmp_audio_explanation_title)
+                .setMessage(R.string.rtmp_audio_explanation_message)
+                .setPositiveButton(R.string.continue_button) { dialog, _ ->
+                    dialog.dismiss()
+                    previewViewModel.toggleVideoSource(mediaProjectionLauncher, rtmpIndex = rtmpIndex)
+                }
+                .setNegativeButton(android.R.string.cancel, null)
+                .show()
+        } else {
+            previewViewModel.toggleVideoSource(mediaProjectionLauncher, rtmpIndex = rtmpIndex)
+        }
+    }
+
+    /**
      * Rebuild dynamic RTMP source buttons (RTMP SRC 2, 3, ...) in the container.
      * The first RTMP SRC button is always in XML; this handles additional sources.
      */
@@ -1148,7 +1169,7 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
                 backgroundTintList = getButtonColorStateList(requireContext(), activeIndex == i)
                 visibility = if (activeIndex != null && activeIndex != i) View.GONE else View.VISIBLE
                 setOnClickListener {
-                    previewViewModel.toggleVideoSource(mediaProjectionLauncher, rtmpIndex = i)
+                    toggleVideoSourceWithExplanation(rtmpIndex = i)
                 }
             }
             container.addView(button)

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -540,6 +540,11 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
     private var _useSystemAudioForCamera = false
     val useSystemAudioForCameraLiveData = MutableLiveData(false)
 
+    fun hasMediaProjection(): Boolean =
+        startupMediaProjection != null
+                || streamingMediaProjection != null
+                || mediaProjectionHelper.getMediaProjection() != null
+
     fun toggleSystemAudioForCamera(
         mediaProjectionLauncher: androidx.activity.result.ActivityResultLauncher<Intent>
     ) {

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -3365,6 +3365,9 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                                             }
                                         }
                                     )
+                                    // MediaProjectionService.startForeground() (ID 1001) overwrote
+                                    // CameraStreamerService notification — restore it.
+                                    try { serviceBinder?.refreshNotification() } catch (_: Throwable) {}
                                 }
                             }
                             // Return early; the actual switch will happen in the projection callback
@@ -3400,6 +3403,9 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                                 }
                             }
                         )
+                        // MediaProjectionService (ID 1001) may have overwritten the
+                        // CameraStreamerService notification — restore it.
+                        try { serviceBinder?.refreshNotification() } catch (_: Throwable) {}
                     }
                 }
                 // If this exact RTMP index is active, switch back to camera

--- a/app/src/main/res/layout/main_fragment.xml
+++ b/app/src/main/res/layout/main_fragment.xml
@@ -257,7 +257,7 @@
                     android:id="@+id/systemAudioToggleButton"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="SYS AUDIO"
+                    android:text="AUDIO OUT"
                     android:backgroundTint="@color/button_gray"
                     app:goneUnless="@{!viewmodel.isRtmpSource}" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,6 +27,9 @@
     <!-- Audio source labels -->
     <string name="audio_source_microphone">Microphone</string>
     <string name="audio_source_bluetooth">Bluetooth</string>
+    <string name="audio_out_explanation_title">Audio Output Capture</string>
+    <string name="audio_out_explanation_message">Records audio output (music, notifications, alarms, system sounds) and use it as stream audio instead of mic.</string>
+    <string name="continue_button">Continue</string>
     <string name="audio_source_rtmp">Media Projection Audio</string>
     <string name="audio_source_none">No Audio</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
     <string name="audio_source_microphone">Microphone</string>
     <string name="audio_source_bluetooth">Bluetooth</string>
     <string name="audio_out_explanation_title">Audio Output Capture</string>
-    <string name="audio_out_explanation_message">Records audio output and uses it as stream audio instead of microphone.\n\nThis includes media, games and other app sounds. Notifications and alarms are not captured.\n\nSome apps can block their audio capture.</string>
+    <string name="audio_out_explanation_message">Records audio output and uses it as stream audio instead of microphone.\n\nIncludes media (music, videos, browser audio), games and other app sounds. Excludes notifications and alarms.\n\nSome apps can block their audio capture.</string>
     <string name="continue_button">Continue</string>
     <string name="rtmp_audio_explanation_title">ExoPlayer Audio Capture</string>
     <string name="rtmp_audio_explanation_message">LifeStreamer uses ExoPlayer to playback RTMP or SRT stream.\n\nApp needs your permission to capture ExoPlayer audio output.\n\nOn newer Android devices please choose to capture LifeStreamer app or entire device when prompted.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,8 @@
     <string name="audio_out_explanation_title">Audio Output Capture</string>
     <string name="audio_out_explanation_message">Records audio output and uses it as stream audio instead of microphone.\n\nThis includes media, games and other app sounds. Notifications and alarms are not captured.\n\nSome apps can block their audio capture.</string>
     <string name="continue_button">Continue</string>
+    <string name="rtmp_audio_explanation_title">Audio Capture Permission</string>
+    <string name="rtmp_audio_explanation_message">LS uses ExoPlayer to play RTMP or SRT stream. App needs your permission to record ExoPlayer audio output.</string>
     <string name="audio_source_rtmp">Media Projection Audio</string>
     <string name="audio_source_none">No Audio</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
     <string name="audio_source_microphone">Microphone</string>
     <string name="audio_source_bluetooth">Bluetooth</string>
     <string name="audio_out_explanation_title">Audio Output Capture</string>
-    <string name="audio_out_explanation_message">Records audio output (music, notifications, alarms, system sounds) and use it as stream audio instead of mic.</string>
+    <string name="audio_out_explanation_message">Records audio output and uses it as stream audio instead of microphone.\n\nThis includes media, games and other app sounds. Notifications and alarms are not captured.\n\nSome apps can block their audio capture.</string>
     <string name="continue_button">Continue</string>
     <string name="audio_source_rtmp">Media Projection Audio</string>
     <string name="audio_source_none">No Audio</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,8 +30,8 @@
     <string name="audio_out_explanation_title">Audio Output Capture</string>
     <string name="audio_out_explanation_message">Records audio output and uses it as stream audio instead of microphone.\n\nThis includes media, games and other app sounds. Notifications and alarms are not captured.\n\nSome apps can block their audio capture.</string>
     <string name="continue_button">Continue</string>
-    <string name="rtmp_audio_explanation_title">Audio Capture Permission</string>
-    <string name="rtmp_audio_explanation_message">LS uses ExoPlayer to play RTMP or SRT stream. App needs your permission to record ExoPlayer audio output.</string>
+    <string name="rtmp_audio_explanation_title">ExoPlayer Audio Capture</string>
+    <string name="rtmp_audio_explanation_message">LifeStreamer uses ExoPlayer to playback RTMP or SRT stream.\n\nApp needs your permission to capture ExoPlayer audio output.\n\nOn newer Android devices please choose to capture LifeStreamer app or entire device when prompted.</string>
     <string name="audio_source_rtmp">Media Projection Audio</string>
     <string name="audio_source_none">No Audio</string>
 


### PR DESCRIPTION
Polishes https://github.com/dimadesu/LifeStreamer/pull/323

- [x] Rename SYS AUDIO to AUDIO OUT
- [x] Fix: Before stream start after switching to RTMP SRC, notification doesn't show Start/Mute/Quit buttons.
  - It shows:
    - Audio Capture Active
    - Capturing ExoPlayer audio for streaming
- Add explanation/info popup before asking MP permission.
  - [x] On AUDIO OUT toggle tap show explanation popup before asking MP permission that will say: "Records audio output (music, notifications, alarms, system sounds) and use it as stream audio instead of mic."
  - [x] On RTMP SRC toggle tap (including dynamically built UI toggles like RTMP SRC 2,  RTMP SRC 3, etc.) show explanation popup before asking MP permission that will say: "LS uses ExoPlayer to play RTMP or SRT stream. App needs your permission to record ExoPlayer audio output."
  - [x] Show info popup separately before.
  - [ ] Add "Do not show again" toggle.
- [x] Add setting at the end of Settings activity to hide AUDIO OUT button as it's a little exotic feature, not everyone needs it.
- [ ] Add setting to hide AUDIO OUT button/toggle?

Test w/ srcs:
- [ ] USB
- [ ] RTMP
- [ ] S23 FE