### PR TITLE
SYS AUDIO/AUDIO OUT feature polish (2nd batch)

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -81,11 +81,6 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
     // BLUETOOTH_CONNECT permission launcher
     private lateinit var bluetoothConnectLauncher: ActivityResultLauncher<String>
 
-    // Track whether each explanation dialog has been shown this session.
-    // Independent flags so both dialogs are shown regardless of MP grant order.
-    private var rtmpAudioExplanationShown = false
-    private var sysAudioExplanationShown = false
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -181,8 +176,8 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
 
         binding.systemAudioToggleButton.setOnClickListener {
             val isTurningOn = previewViewModel.useSystemAudioForCameraLiveData.value != true
-            if (isTurningOn && !sysAudioExplanationShown) {
-                sysAudioExplanationShown = true
+            if (isTurningOn && !previewViewModel.sysAudioExplanationShown) {
+                previewViewModel.sysAudioExplanationShown = true
                 androidx.appcompat.app.AlertDialog.Builder(requireContext())
                     .setTitle(R.string.audio_out_explanation_title)
                     .setMessage(R.string.audio_out_explanation_message)
@@ -191,7 +186,7 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
                         previewViewModel.toggleSystemAudioForCamera(mediaProjectionLauncher)
                     }
                     .setNegativeButton(android.R.string.cancel) { _, _ ->
-                        sysAudioExplanationShown = false // reset so it shows again if user cancelled
+                        previewViewModel.sysAudioExplanationShown = false
                     }
                     .show()
             } else {
@@ -1138,8 +1133,8 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
      */
     private fun toggleVideoSourceWithExplanation(rtmpIndex: Int) {
         val isSwitchingTo = previewViewModel.activeRtmpIndex.value != rtmpIndex
-        if (isSwitchingTo && !rtmpAudioExplanationShown) {
-            rtmpAudioExplanationShown = true
+        if (isSwitchingTo && !previewViewModel.rtmpAudioExplanationShown) {
+            previewViewModel.rtmpAudioExplanationShown = true
             androidx.appcompat.app.AlertDialog.Builder(requireContext())
                 .setTitle(R.string.rtmp_audio_explanation_title)
                 .setMessage(R.string.rtmp_audio_explanation_message)
@@ -1148,7 +1143,7 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
                     previewViewModel.toggleVideoSource(mediaProjectionLauncher, rtmpIndex = rtmpIndex)
                 }
                 .setNegativeButton(android.R.string.cancel) { _, _ ->
-                    rtmpAudioExplanationShown = false // reset so it shows again if user cancelled
+                    previewViewModel.rtmpAudioExplanationShown = false
                 }
                 .show()
         } else {

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -2271,19 +2271,17 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                 rtmpRetryJob = null
                 Log.d(TAG, "Cancelled RTMP retry job before reconnection")
                 
-                // For RTMP/Bitmap sources with MediaProjection audio: switch to microphone before close()
-                // MediaProjection tokens become invalid after close(), so we can't reuse them
-                // We'll upgrade back to MediaProjection after successful reconnection with a fresh token
-                val currentVideoSource = currentStreamer.videoInput?.sourceFlow?.value
+                // For sources using MediaProjection audio: switch to microphone before close()
+                // MediaProjection tokens become invalid after close(), so we can't reuse them.
+                // This covers both RTMP/Bitmap (own-app MP) and camera/UVC with SYS AUDIO (full-phone MP).
                 val currentAudioSource = currentStreamer.audioInput?.sourceFlow?.value
-                val isRtmpOrBitmap = currentVideoSource != null && currentVideoSource !is io.github.thibaultbee.streampack.core.elements.sources.video.camera.ICameraSource
                 val hasMediaProjectionAudio = currentAudioSource is IMediaProjectionSource
                 
-                if (isRtmpOrBitmap && hasMediaProjectionAudio) {
+                if (hasMediaProjectionAudio) {
                     try {
                         currentStreamer.setAudioSource(com.dimadesu.lifestreamer.audio.ConditionalAudioSourceFactory())
                         needsMediaProjectionAudioRestore = true
-                        Log.d(TAG, "Switched to conditional source before reconnection (will restore MediaProjection after)")
+                        Log.d(TAG, "Switched to conditional source before reconnection (will restore via setAudioSourceBasedOnVideoSource after)")
                     } catch (e: Exception) {
                         Log.w(TAG, "Failed to switch audio source before reconnection: ${e.message}")
                         needsMediaProjectionAudioRestore = false
@@ -2437,23 +2435,18 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                     // Clear any stored rotation since we successfully reconnected with locked orientation
                     rotationIgnoredDuringReconnection = null
                     
-                    // Restore MediaProjection audio if we switched to microphone before reconnection
+                    // Restore MediaProjection audio if we switched to microphone before reconnection.
+                    // Use setAudioSourceBasedOnVideoSource() to correctly handle all cases:
+                    // - RTMP/Bitmap → MP without captureFullPhone
+                    // - UVC/Camera + SYS AUDIO → MP with captureFullPhone=true
                     if (needsMediaProjectionAudioRestore) {
                         Log.d(TAG, "Restoring MediaProjection audio after reconnection")
                         needsMediaProjectionAudioRestore = false
-                        
                         try {
-                            // Get MediaProjection from helper if we don't have it yet
-                            val mediaProjection = streamingMediaProjection ?: mediaProjectionHelper.getMediaProjection()
-                            if (mediaProjection != null) {
-                                // Set MediaProjection audio source directly
-                                currentStreamer.setAudioSource(MediaProjectionAudioSourceFactory(mediaProjection))
-                                Log.i(TAG, "Restored MediaProjection audio after reconnection")
-                            } else {
-                                Log.w(TAG, "Could not restore MediaProjection audio: MediaProjection not available")
-                            }
+                            setAudioSourceBasedOnVideoSource()
+                            Log.i(TAG, "Restored audio source after reconnection")
                         } catch (e: Exception) {
-                            Log.w(TAG, "Failed to restore MediaProjection audio: ${e.message}")
+                            Log.w(TAG, "Failed to restore audio source after reconnection: ${e.message}")
                         }
                     }
                     

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -545,6 +545,9 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                 || streamingMediaProjection != null
                 || mediaProjectionHelper.getMediaProjection() != null
 
+    var rtmpAudioExplanationShown = false
+    var sysAudioExplanationShown = false
+
     fun toggleSystemAudioForCamera(
         mediaProjectionLauncher: androidx.activity.result.ActivityResultLauncher<Intent>
     ) {

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -4571,21 +4571,22 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                 storageRepository.saveAudioSourceType(sourceType)
                 Log.d(TAG, "Saved audio source type to DataStore")
 
-                // Only switch to built-in mic if BT mic and SYS AUDIO are both inactive.
-                // When BT or MP is active, the preference is saved and will apply next time
+                // Only switch to built-in mic if BT mic, SYS AUDIO, and RTMP source are all inactive.
+                // When BT, MP, or RTMP is active, the preference is saved and will apply next time
                 // ConditionalAudioSourceFactory is used (e.g. after SYS AUDIO is toggled off).
                 val btActive = _useBluetoothMic.value == true
                 val sysAudioActive = _useSystemAudioForCamera
-                if (btActive || sysAudioActive) {
+                val rtmpActive = _activeRtmpIndex.value != null
+                if (btActive || sysAudioActive || rtmpActive) {
                     Log.i(TAG, "Audio source preference saved but not applied — " +
-                            "BT=$btActive, SYS=$sysAudioActive override is active")
+                            "BT=$btActive, SYS=$sysAudioActive, RTMP=$rtmpActive override is active")
                 } else {
                     currentStreamer.setAudioSource(ConditionalAudioSourceFactory())
                     Log.i(TAG, "Audio source changed to: ${getAudioSourceName(sourceType)}")
                 }
                 
                 // If audio monitoring is enabled and we actually switched the source, restart passthrough
-                if (!btActive && !sysAudioActive && _isMonitorAudioOn.value == true) {
+                if (!btActive && !sysAudioActive && !rtmpActive && _isMonitorAudioOn.value == true) {
                     Log.i(TAG, "Restarting audio passthrough with new settings")
                     service?.stopAudioPassthrough()
                     delay(100) // Small delay to ensure clean restart

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -625,7 +625,6 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
     
     private var lastDisconnectReason: String? = null
     private var rotationIgnoredDuringReconnection: Int? = null // Store rotation changes during reconnection
-    private var needsMediaProjectionAudioRestore = false // Track if we need to restore MediaProjection audio after reconnection
     
     // LiveData for reconnection status UI feedback
     private val _reconnectionStatusLiveData = MutableLiveData<String?>()
@@ -2271,23 +2270,6 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                 rtmpRetryJob = null
                 Log.d(TAG, "Cancelled RTMP retry job before reconnection")
                 
-                // For sources using MediaProjection audio: switch to microphone before close()
-                // MediaProjection tokens become invalid after close(), so we can't reuse them.
-                // This covers both RTMP/Bitmap (own-app MP) and camera/UVC with SYS AUDIO (full-phone MP).
-                val currentAudioSource = currentStreamer.audioInput?.sourceFlow?.value
-                val hasMediaProjectionAudio = currentAudioSource is IMediaProjectionSource
-                
-                if (hasMediaProjectionAudio) {
-                    try {
-                        currentStreamer.setAudioSource(com.dimadesu.lifestreamer.audio.ConditionalAudioSourceFactory())
-                        needsMediaProjectionAudioRestore = true
-                        Log.d(TAG, "Switched to conditional source before reconnection (will restore via setAudioSourceBasedOnVideoSource after)")
-                    } catch (e: Exception) {
-                        Log.w(TAG, "Failed to switch audio source before reconnection: ${e.message}")
-                        needsMediaProjectionAudioRestore = false
-                    }
-                }
-                
                 // Clean up current connection
                 // Only call stopStream() if stream was actually started
                 // If open() failed, the stream is not running and stopStream() will hang
@@ -2434,21 +2416,6 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                     
                     // Clear any stored rotation since we successfully reconnected with locked orientation
                     rotationIgnoredDuringReconnection = null
-                    
-                    // Restore MediaProjection audio if we switched to microphone before reconnection.
-                    // Use setAudioSourceBasedOnVideoSource() to correctly handle all cases:
-                    // - RTMP/Bitmap → MP without captureFullPhone
-                    // - UVC/Camera + SYS AUDIO → MP with captureFullPhone=true
-                    if (needsMediaProjectionAudioRestore) {
-                        Log.d(TAG, "Restoring MediaProjection audio after reconnection")
-                        needsMediaProjectionAudioRestore = false
-                        try {
-                            setAudioSourceBasedOnVideoSource()
-                            Log.i(TAG, "Restored audio source after reconnection")
-                        } catch (e: Exception) {
-                            Log.w(TAG, "Failed to restore audio source after reconnection: ${e.message}")
-                        }
-                    }
                     
                     // If reconnected with bitmap source and user had RTMP toggled,
                     // restart the RTMP source retry loop so it eventually switches back to RTMP video.


### PR DESCRIPTION
Continues work done in https://github.com/dimadesu/LifeStreamer/pull/325

- [x] Fix: State for popup is lost on view resize

Related, but not really AUDIO OUT issues:
- [x] When on RTMP SRC, go to Settings activity, change audio source (example: CAMCORDER to VOICE COMMUNICATION), then come back to main screen - stream audio switched to built-in mic, when it should stay on Media Projection.
- USB
  - [x] Fix: On stream reconnect with AUDIO OUT on stream audio is set to MP that is designed for RTMP.
- [x] Fix: In reconnect mode based on old logic the stream audio was set to built-in mic as it though MP token is invalidated.

Test
- [ ] S23 FE