### PR TITLE
AUDIO OUT feature polish (3rd batch)

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
@@ -473,13 +473,6 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
                         clearUserStoppedManually()
                         
                         try {
-                            // Check if we're using RTMP source - can't start from notification
-                            if (isUsingRtmpSource()) {
-                                Log.i(TAG, "Cannot start RTMP stream from notification - updating notification")
-                                showCannotStartRtmpNotification()
-                                return@launch
-                            }
-                            
                             startStreamFromConfiguredEndpoint()
                         } catch (e: Exception) {
                             Log.w(TAG, "Start from notification failed: ${e.message}")
@@ -949,17 +942,6 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
     }
     
     /**
-     * Show a notification when user tries to start RTMP stream from notification.
-     * RTMP streams can only be started from the app due to MediaProjection permission requirements.
-     */
-    private fun showCannotStartRtmpNotification() {
-        val notification = createDefaultNotification(
-            content = "Can't start with RTMP source from notification"
-        )
-        customNotificationUtils.notify(notification)
-    }
-    
-    /**
      * Create a standard notification with default settings.
      * Used by onCreateNotification() and other notification methods.
      * 
@@ -1003,18 +985,6 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
             Log.d(TAG, "Sources validated - video: ${videoSource.javaClass.simpleName}, audio: ${audioSource.javaClass.simpleName}")
             true to null
         }
-    }
-    
-    /**
-     * Check if the current video source is RTMP.
-     * RTMP sources cannot be started from notifications due to MediaProjection permission requirements.
-     * 
-     * @return true if current video source is RTMP, false otherwise
-     */
-    private fun isUsingRtmpSource(): Boolean {
-        val currentStreamer = streamer
-        val videoSource = (currentStreamer as? io.github.thibaultbee.streampack.core.interfaces.IWithVideoSource)?.videoInput?.sourceFlow?.value
-        return videoSource is com.dimadesu.lifestreamer.rtmp.video.RTMPVideoSource
     }
     
     /**

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/ExplanationDialogFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/ExplanationDialogFragment.kt
@@ -1,0 +1,54 @@
+package com.dimadesu.lifestreamer.ui.main
+
+import android.app.Dialog
+import android.os.Bundle
+import androidx.appcompat.app.AlertDialog
+import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.setFragmentResult
+import com.dimadesu.lifestreamer.R
+
+/**
+ * Reusable explanation dialog that survives orientation changes.
+ * Communicates result via Fragment Result API using the provided request key.
+ * Result bundle contains "confirmed" (Boolean).
+ */
+class ExplanationDialogFragment : DialogFragment() {
+
+    companion object {
+        const val SYS_AUDIO_TAG = "sys_audio_explanation"
+        const val RTMP_AUDIO_TAG = "rtmp_audio_explanation"
+
+        const val RESULT_CONFIRMED = "confirmed"
+
+        private const val ARG_TITLE = "title"
+        private const val ARG_MESSAGE = "message"
+        private const val ARG_REQUEST_KEY = "request_key"
+
+        fun newInstance(titleRes: Int, messageRes: Int, requestKey: String) =
+            ExplanationDialogFragment().apply {
+                arguments = bundleOf(
+                    ARG_TITLE to titleRes,
+                    ARG_MESSAGE to messageRes,
+                    ARG_REQUEST_KEY to requestKey
+                )
+            }
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val titleRes = requireArguments().getInt(ARG_TITLE)
+        val messageRes = requireArguments().getInt(ARG_MESSAGE)
+        val requestKey = requireArguments().getString(ARG_REQUEST_KEY)!!
+
+        return AlertDialog.Builder(requireContext())
+            .setTitle(titleRes)
+            .setMessage(messageRes)
+            .setPositiveButton(R.string.continue_button) { _, _ ->
+                setFragmentResult(requestKey, bundleOf(RESULT_CONFIRMED to true))
+            }
+            .setNegativeButton(android.R.string.cancel) { _, _ ->
+                setFragmentResult(requestKey, bundleOf(RESULT_CONFIRMED to false))
+            }
+            .create()
+    }
+}

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -112,6 +112,26 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
 
     @SuppressLint("MissingPermission")
     private fun bindProperties() {
+        childFragmentManager.setFragmentResultListener(
+            ExplanationDialogFragment.SYS_AUDIO_TAG, viewLifecycleOwner
+        ) { _, result ->
+            if (result.getBoolean(ExplanationDialogFragment.RESULT_CONFIRMED)) {
+                previewViewModel.sysAudioExplanationShown = true
+                previewViewModel.toggleSystemAudioForCamera(mediaProjectionLauncher)
+            }
+        }
+
+        childFragmentManager.setFragmentResultListener(
+            ExplanationDialogFragment.RTMP_AUDIO_TAG, viewLifecycleOwner
+        ) { _, result ->
+            if (result.getBoolean(ExplanationDialogFragment.RESULT_CONFIRMED)) {
+                previewViewModel.rtmpAudioExplanationShown = true
+                val rtmpIndex = previewViewModel.pendingRtmpIndex ?: return@setFragmentResultListener
+                previewViewModel.pendingRtmpIndex = null
+                previewViewModel.toggleVideoSource(mediaProjectionLauncher, rtmpIndex = rtmpIndex)
+            }
+        }
+
         binding.liveButton.setOnClickListener {
             // Use streamStatus as single source of truth for determining action
             val currentStatus = previewViewModel.streamStatus.value
@@ -177,16 +197,13 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
         binding.systemAudioToggleButton.setOnClickListener {
             val isTurningOn = previewViewModel.useSystemAudioForCameraLiveData.value != true
             if (isTurningOn && !previewViewModel.sysAudioExplanationShown) {
-                androidx.appcompat.app.AlertDialog.Builder(requireContext())
-                    .setTitle(R.string.audio_out_explanation_title)
-                    .setMessage(R.string.audio_out_explanation_message)
-                    .setPositiveButton(R.string.continue_button) { dialog, _ ->
-                        previewViewModel.sysAudioExplanationShown = true
-                        dialog.dismiss()
-                        previewViewModel.toggleSystemAudioForCamera(mediaProjectionLauncher)
-                    }
-                    .setNegativeButton(android.R.string.cancel, null)
-                    .show()
+                if (childFragmentManager.findFragmentByTag(ExplanationDialogFragment.SYS_AUDIO_TAG) == null) {
+                    ExplanationDialogFragment.newInstance(
+                        R.string.audio_out_explanation_title,
+                        R.string.audio_out_explanation_message,
+                        ExplanationDialogFragment.SYS_AUDIO_TAG
+                    ).show(childFragmentManager, ExplanationDialogFragment.SYS_AUDIO_TAG)
+                }
             } else {
                 previewViewModel.toggleSystemAudioForCamera(mediaProjectionLauncher)
             }
@@ -1132,16 +1149,14 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
     private fun toggleVideoSourceWithExplanation(rtmpIndex: Int) {
         val isSwitchingTo = previewViewModel.activeRtmpIndex.value != rtmpIndex
         if (isSwitchingTo && !previewViewModel.rtmpAudioExplanationShown) {
-            androidx.appcompat.app.AlertDialog.Builder(requireContext())
-                .setTitle(R.string.rtmp_audio_explanation_title)
-                .setMessage(R.string.rtmp_audio_explanation_message)
-                .setPositiveButton(R.string.continue_button) { dialog, _ ->
-                    previewViewModel.rtmpAudioExplanationShown = true
-                    dialog.dismiss()
-                    previewViewModel.toggleVideoSource(mediaProjectionLauncher, rtmpIndex = rtmpIndex)
-                }
-                .setNegativeButton(android.R.string.cancel, null)
-                .show()
+            previewViewModel.pendingRtmpIndex = rtmpIndex
+            if (childFragmentManager.findFragmentByTag(ExplanationDialogFragment.RTMP_AUDIO_TAG) == null) {
+                ExplanationDialogFragment.newInstance(
+                    R.string.rtmp_audio_explanation_title,
+                    R.string.rtmp_audio_explanation_message,
+                    ExplanationDialogFragment.RTMP_AUDIO_TAG
+                ).show(childFragmentManager, ExplanationDialogFragment.RTMP_AUDIO_TAG)
+            }
         } else {
             previewViewModel.toggleVideoSource(mediaProjectionLauncher, rtmpIndex = rtmpIndex)
         }

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -177,17 +177,15 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
         binding.systemAudioToggleButton.setOnClickListener {
             val isTurningOn = previewViewModel.useSystemAudioForCameraLiveData.value != true
             if (isTurningOn && !previewViewModel.sysAudioExplanationShown) {
-                previewViewModel.sysAudioExplanationShown = true
                 androidx.appcompat.app.AlertDialog.Builder(requireContext())
                     .setTitle(R.string.audio_out_explanation_title)
                     .setMessage(R.string.audio_out_explanation_message)
                     .setPositiveButton(R.string.continue_button) { dialog, _ ->
+                        previewViewModel.sysAudioExplanationShown = true
                         dialog.dismiss()
                         previewViewModel.toggleSystemAudioForCamera(mediaProjectionLauncher)
                     }
-                    .setNegativeButton(android.R.string.cancel) { _, _ ->
-                        previewViewModel.sysAudioExplanationShown = false
-                    }
+                    .setNegativeButton(android.R.string.cancel, null)
                     .show()
             } else {
                 previewViewModel.toggleSystemAudioForCamera(mediaProjectionLauncher)
@@ -1134,17 +1132,15 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
     private fun toggleVideoSourceWithExplanation(rtmpIndex: Int) {
         val isSwitchingTo = previewViewModel.activeRtmpIndex.value != rtmpIndex
         if (isSwitchingTo && !previewViewModel.rtmpAudioExplanationShown) {
-            previewViewModel.rtmpAudioExplanationShown = true
             androidx.appcompat.app.AlertDialog.Builder(requireContext())
                 .setTitle(R.string.rtmp_audio_explanation_title)
                 .setMessage(R.string.rtmp_audio_explanation_message)
                 .setPositiveButton(R.string.continue_button) { dialog, _ ->
+                    previewViewModel.rtmpAudioExplanationShown = true
                     dialog.dismiss()
                     previewViewModel.toggleVideoSource(mediaProjectionLauncher, rtmpIndex = rtmpIndex)
                 }
-                .setNegativeButton(android.R.string.cancel) { _, _ ->
-                    previewViewModel.rtmpAudioExplanationShown = false
-                }
+                .setNegativeButton(android.R.string.cancel, null)
                 .show()
         } else {
             previewViewModel.toggleVideoSource(mediaProjectionLauncher, rtmpIndex = rtmpIndex)

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -1144,11 +1144,12 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
 
     /**
      * Toggle RTMP video source, showing an explanation dialog before requesting
-     * MediaProjection permission when the user is switching to RTMP for the first time.
+     * MediaProjection permission when the user is switching to RTMP for the first time
+     * and no MediaProjection token exists yet.
      */
     private fun toggleVideoSourceWithExplanation(rtmpIndex: Int) {
         val isSwitchingTo = previewViewModel.activeRtmpIndex.value != rtmpIndex
-        if (isSwitchingTo && !previewViewModel.rtmpAudioExplanationShown) {
+        if (isSwitchingTo && !previewViewModel.rtmpAudioExplanationShown && !previewViewModel.hasMediaProjection()) {
             previewViewModel.pendingRtmpIndex = rtmpIndex
             if (childFragmentManager.findFragmentByTag(ExplanationDialogFragment.RTMP_AUDIO_TAG) == null) {
                 ExplanationDialogFragment.newInstance(

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -547,6 +547,7 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
 
     var rtmpAudioExplanationShown = false
     var sysAudioExplanationShown = false
+    var pendingRtmpIndex: Int? = null
 
     fun toggleSystemAudioForCamera(
         mediaProjectionLauncher: androidx.activity.result.ActivityResultLauncher<Intent>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,7 +31,7 @@
     <string name="audio_out_explanation_message">Records audio output and uses it as stream audio instead of microphone.\n\nIncludes media (music, videos, browser audio), games and other app sounds. Excludes notifications and alarms.\n\nSome apps can block their audio capture.</string>
     <string name="continue_button">Continue</string>
     <string name="rtmp_audio_explanation_title">ExoPlayer Audio Capture</string>
-    <string name="rtmp_audio_explanation_message">LifeStreamer uses ExoPlayer to playback RTMP or SRT stream.\n\nApp needs your permission to capture ExoPlayer audio output.\n\nOn newer Android devices please choose to capture LifeStreamer app or entire device when prompted.</string>
+    <string name="rtmp_audio_explanation_message">LifeStreamer uses ExoPlayer to playback RTMP or SRT stream. App needs your permission to capture ExoPlayer audio output.\n\nNew Android versions ask to choose a single app or the entire device for video capture. This choice has no effect on audio capture. For RTMP SRC feature LS records only own (ExoPlayer) audio and nothing else.</string>
     <string name="audio_source_rtmp">Media Projection Audio</string>
     <string name="audio_source_none">No Audio</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
     <string name="audio_source_microphone">Microphone</string>
     <string name="audio_source_bluetooth">Bluetooth</string>
     <string name="audio_out_explanation_title">Audio Output Capture</string>
-    <string name="audio_out_explanation_message">Records audio output and uses it as stream audio instead of microphone.\n\nIncludes media (music, videos, browser audio), games and other app sounds. Excludes notifications and alarms.\n\nSome apps can block their audio capture.</string>
+    <string name="audio_out_explanation_message">Record audio output and use it as stream audio instead of the microphone.\n\nIncludes media (music, videos, browser audio), games and other app sounds. Excludes notifications and alarms.\n\nSome apps can block their audio capture.</string>
     <string name="continue_button">Continue</string>
     <string name="rtmp_audio_explanation_title">ExoPlayer Audio Capture</string>
     <string name="rtmp_audio_explanation_message">LifeStreamer uses ExoPlayer to playback RTMP or SRT stream. App needs your permission to capture ExoPlayer audio output.\n\nNew Android versions ask to choose a single app or the entire device for video capture. This choice has no effect on audio capture. For RTMP SRC feature LS records only own (ExoPlayer) audio and nothing else.</string>


### PR DESCRIPTION
Continues work done in https://github.com/dimadesu/LifeStreamer/pull/326

- [x] Fix: Open popup should stay open on orientation change
- [x] Update popup copy
- [x] Skip RTMP SRC popup if MP token already exists.
- [x] Remove code that blocked stream start from notification for RTMP SRC.