### PR TITLE
Fix: BT mic disconnects on earbuds play button click, but BT toggle stays on

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/audio/BluetoothAudioManager.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/audio/BluetoothAudioManager.kt
@@ -47,11 +47,12 @@ class BluetoothAudioManager(
     private var scoDisconnectReceiver: BroadcastReceiver? = null
     private var btDeviceReceiver: BroadcastReceiver? = null
     private var btDeviceMonitorJob: Job? = null
+    @Volatile private var isHandlingDisconnect = false
     
     /**
      * SCO negotiation state exposed to UI
      */
-    enum class ScoState { IDLE, TRYING, USING_BT, FAILED }
+    enum class ScoState { IDLE, TRYING, USING_BT, FAILED, DISCONNECTED }
     
     private val _scoStateFlow = MutableStateFlow(ScoState.IDLE)
     val scoStateFlow: StateFlow<ScoState> = _scoStateFlow.asStateFlow()
@@ -395,17 +396,23 @@ class BluetoothAudioManager(
 
     /**
      * Handle SCO disconnection by reverting to built-in mic.
+     * Guarded against multiple concurrent invocations (Android sends several broadcasts).
      */
     private fun handleScoDisconnect(streamerInstance: ISingleStreamer?) {
+        if (isHandlingDisconnect) return
+        isHandlingDisconnect = true
+        _scoStateFlow.tryEmit(ScoState.DISCONNECTED)
         scope.launch(Dispatchers.Default) {
             try {
                 stopScoAndResetAudio()
                 delay(250)
                 recreateMicSource(streamerInstance)
                 delay(150)
-                _scoStateFlow.tryEmit(ScoState.IDLE)
             } catch (t: Throwable) {
                 Log.w(TAG, "Failed to revert to mic on SCO disconnect: ${t.message}")
+            } finally {
+                isHandlingDisconnect = false
+                _scoStateFlow.tryEmit(ScoState.IDLE)
             }
         }
     }

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -1232,16 +1232,20 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                                 scoFlow.collect { state ->
                                     try { _scoStateLiveData.postValue(state.name) } catch (_: Throwable) {}
 
-                                    // If SCO negotiation failed, revert user toggle and notify UI
+                                    // If SCO failed or was unexpectedly disconnected, revert user toggle and notify UI
                                     try {
-                                        val failedEnum = com.dimadesu.lifestreamer.audio.BluetoothAudioManager.ScoState.FAILED
-                                        if (state == failedEnum) {
-                                            // Update UI toggle
-                                            _useBluetoothMic.postValue(false)
-                                            // Inform the service via binder (best-effort)
-                                            try { serviceBinder?.setUseBluetoothMic(false) } catch (_: Throwable) {}
-                                            // Notify user
-                                            try { _toastMessageLiveData.postValue("Bluetooth mic unavailable") } catch (_: Throwable) {}
+                                        when (state) {
+                                            com.dimadesu.lifestreamer.audio.BluetoothAudioManager.ScoState.FAILED -> {
+                                                _useBluetoothMic.postValue(false)
+                                                try { serviceBinder?.setUseBluetoothMic(false) } catch (_: Throwable) {}
+                                                try { _toastMessageLiveData.postValue("Bluetooth mic unavailable") } catch (_: Throwable) {}
+                                            }
+                                            com.dimadesu.lifestreamer.audio.BluetoothAudioManager.ScoState.DISCONNECTED -> {
+                                                _useBluetoothMic.postValue(false)
+                                                try { serviceBinder?.setUseBluetoothMic(false) } catch (_: Throwable) {}
+                                                try { _toastMessageLiveData.postValue("Bluetooth mic disconnected") } catch (_: Throwable) {}
+                                            }
+                                            else -> {}
                                         }
                                     } catch (_: Throwable) {}
                                 }


### PR DESCRIPTION
 What was fixed:

1. Triple-firing — isHandlingDisconnect flag prevents the 3 rapid SCO broadcast callbacks from each spawning a coroutine. Only the first one runs; the others return immediately.
2. BT toggle staying on — Added ScoState.DISCONNECTED emitted immediately when unexpected SCO drop is detected. The ViewModel now reacts to it by turning off _useBluetoothMic and showing "Bluetooth mic disconnected" toast, same as it does for FAILED.
   
---

The user is observing that when they press the button on their BT earbuds, the BT earbuds stay connected (they can still play audio through them), but LS loses the SCO connection. 

That's expected — BT earbuds use two separate profiles simultaneously:

 - A2DP — high-quality audio playback (music, games). This is why you can still hear audio after the button press. It stays connected.
 - HFP/SCO — voice/microphone channel. This is what LS uses for the BT mic. This is the one that dropped.

When you pressed the button, the earbuds likely toggled the HFP connection (pause/resume in HFP mode conflicts with an active SCO session on many firmware implementations). The A2DP connection was untouched, so audio playback keeps working fine.

So it's not a bug with the earbuds per se — it's a known friction point between SCO (used for mic capture) and earbud media controls. The fix we just made correctly handles this: LS now detects the SCO drop, reverts to built-in mic, turns off the BT toggle, and shows "Bluetooth mic disconnected".