### PR TITLE
Don't reset video encoder FPS to 30 on video encoder change

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/settings/SettingsFragment.kt
@@ -346,7 +346,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
         }
         val savedVideoFps = videoFpsListPreference.value
         videoFpsListPreference.value =
-            if (!resetToDefaults && videoFpsListPreference.findIndexOfValue(savedVideoFps) >= 0) savedVideoFps
+            if (videoFpsListPreference.findIndexOfValue(savedVideoFps) >= 0) savedVideoFps
             else getString(R.string.default_fps)
         videoFpsListPreference.refreshStaleSettingUi()
 
@@ -362,7 +362,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
         }
         val savedCameraFps = cameraFpsListPreference.value
         cameraFpsListPreference.value =
-            if (!resetToDefaults && cameraFpsListPreference.findIndexOfValue(savedCameraFps) >= 0) savedCameraFps
+            if (cameraFpsListPreference.findIndexOfValue(savedCameraFps) >= 0) savedCameraFps
             else getString(R.string.default_fps)
         cameraFpsListPreference.refreshStaleSettingUi()
         cameraFpsListPreference.setOnPreferenceChangeListener { _, newValue ->


### PR DESCRIPTION
I updated the logic in SettingsFragment.kt so that it no longer forcefully wipes your FPS settings when you change encoders.

Now, when you switch the Video Encoder:

- The app checks if your currently saved Video Encoder FPS and Camera FPS are actually supported by the new encoder.
- If they are supported, it keeps your saved values perfectly intact.
- If the new encoder doesn't support them, it falls back to the default (30) so the app doesn't crash.

The build compiled successfully, so your FPS settings should now be much more "sticky" and stop reverting to 30 unnecessarily!