### PR TITLE
Resize video preview to match aspect ratio of video encoder resolution

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,6 +51,7 @@
         <activity
             android:name=".ui.main.MainActivity"
             android:exported="true"
+            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -245,6 +245,12 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
             updateRtmpButtonColors(activeIndex)
         }
 
+        // Dynamically adjust preview aspect ratio to match the stream resolution.
+        // Also called from onConfigurationChanged so rotation re-applies the correct scale.
+        previewViewModel.videoConfigLiveData.observe(viewLifecycleOwner) { config ->
+            applyPreviewScale(config)
+        }
+
         previewViewModel.streamerErrorLiveData.observe(viewLifecycleOwner) { error ->
             error?.let {
                 showError("Oops", it)
@@ -649,6 +655,52 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
 
     override fun onDestroyView() {
         super.onDestroyView()
+    }
+
+    override fun onConfigurationChanged(newConfig: android.content.res.Configuration) {
+        super.onConfigurationChanged(newConfig)
+        applyPreviewScale(previewViewModel.videoConfigLiveData.value)
+    }
+
+    /**
+     * Sizes the PreviewView to exactly match the stream resolution, then visually scales it
+     * down (via scaleX/scaleY) so it fits inside the available screen area.
+     * Using scale instead of layout resize avoids SurfaceView surface destruction, which
+     * would otherwise crash the Samsung Camera HAL during active streams.
+     */
+    private fun applyPreviewScale(config: io.github.thibaultbee.streampack.core.streamers.single.VideoConfig?) {
+        config ?: return
+        val width = config.resolution.width
+        val height = config.resolution.height
+        if (width <= 0 || height <= 0) return
+
+        val isPortrait = resources.configuration.orientation ==
+                android.content.res.Configuration.ORIENTATION_PORTRAIT
+        val targetW = if (isPortrait) height else width
+        val targetH = if (isPortrait) width else height
+
+        // Set the layout size so StreamPack selects the correct camera resolution
+        val lp = binding.preview.layoutParams as androidx.constraintlayout.widget.ConstraintLayout.LayoutParams
+        lp.dimensionRatio = null
+        lp.width = targetW
+        lp.height = targetH
+        binding.preview.layoutParams = lp
+
+        // After the layout pass, scale the view down to fit the visible area
+        binding.root.post {
+            val availableWidth = binding.root.width.toFloat()
+            val availableHeight = binding.root.height.toFloat()
+            if (availableWidth > 0 && availableHeight > 0) {
+                val scale = kotlin.math.min(
+                    availableWidth / targetW.toFloat(),
+                    availableHeight / targetH.toFloat()
+                )
+                binding.preview.pivotX = targetW / 2f
+                binding.preview.pivotY = targetH / 2f
+                binding.preview.scaleX = scale
+                binding.preview.scaleY = scale
+            }
+        }
     }
 
     private fun showPermissionError(vararg permissions: String) {

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -3923,6 +3923,8 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
         .map { it != null }
         .asLiveData()
 
+    val videoConfigLiveData: LiveData<VideoConfig?> = storageRepository.videoConfigFlow.asLiveData()
+
     private val _isSrtlaStatsVisible = MutableLiveData(false)
     val isSrtlaStatsVisible: LiveData<Boolean> = _isSrtlaStatsVisible
 

--- a/app/src/main/res/layout/main_fragment.xml
+++ b/app/src/main/res/layout/main_fragment.xml
@@ -20,7 +20,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             app:enableZoomOnPinch="true"
-            app:layout_constraintBottom_toTopOf="@+id/liveButton"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
- Implemented applyPreviewScale in PreviewFragment to force the PreviewView layout dimensions to match the encoder stream resolution, and then visually scale it to fit the screen using scaleX/scaleY. This ensures true WYSIWYG framing without black bars.

- Added android:configChanges to MainActivity and onConfigurationChanged to PreviewFragment to recalculate preview scaling dynamically on rotation. This prevents Activity recreation, avoiding the intermittent Samsung Camera HAL timeout crash.

- Exposed videoConfigLiveData in PreviewViewModel to trigger preview scaling updates when the user modifies stream settings.

- Centered the PreviewView to remove extra empty space and cleaned up unused layout IDs in main_fragment.xml.