### PR TITLE
Add stream orientation setting. Version 1. Separate stream and preview settings

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/data/storage/DataStoreRepository.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/data/storage/DataStoreRepository.kt
@@ -344,6 +344,12 @@ class DataStoreRepository(
         }
     }.distinctUntilChanged()
 
+    val streamOrientationFlow: Flow<com.dimadesu.lifestreamer.models.StreamOrientation> = dataStore.data.map { preferences ->
+        val stored = preferences[stringPreferencesKey(context.getString(R.string.stream_orientation_key))]
+            ?: context.getString(R.string.stream_orientation_value_auto)
+        com.dimadesu.lifestreamer.models.StreamOrientation.fromId(stored)
+    }.distinctUntilChanged()
+
     // Save methods for audio settings
     suspend fun saveAudioSourceType(sourceType: Int) {
         dataStore.edit { preferences ->

--- a/app/src/main/java/com/dimadesu/lifestreamer/data/storage/DataStoreRepository.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/data/storage/DataStoreRepository.kt
@@ -356,4 +356,16 @@ class DataStoreRepository(
             preferences[stringPreferencesKey(context.getString(R.string.audio_source_type_key))] = sourceType.toString()
         }
     }
+
+    // --- View Orientation Settings ---
+
+    val viewOrientationSettingFlow: Flow<Int> = dataStore.data.map { preferences ->
+        preferences[intPreferencesKey("view_orientation_setting")] ?: android.content.pm.ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+    }.distinctUntilChanged()
+
+    suspend fun saveViewOrientationSetting(setting: Int) {
+        dataStore.edit { preferences ->
+            preferences[intPreferencesKey("view_orientation_setting")] = setting
+        }
+    }
 }

--- a/app/src/main/java/com/dimadesu/lifestreamer/models/StreamOrientation.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/models/StreamOrientation.kt
@@ -1,0 +1,24 @@
+package com.dimadesu.lifestreamer.models
+
+import android.view.Surface
+
+enum class StreamOrientation(val id: String) {
+    AUTO("auto"),
+    PORTRAIT("portrait"),
+    LANDSCAPE("landscape"),
+    PORTRAIT_REVERSED("portrait_reversed"),
+    LANDSCAPE_REVERSED("landscape_reversed");
+
+    fun toSurfaceRotation(): Int? = when (this) {
+        AUTO -> null
+        PORTRAIT -> Surface.ROTATION_0
+        LANDSCAPE -> Surface.ROTATION_90
+        PORTRAIT_REVERSED -> Surface.ROTATION_180
+        LANDSCAPE_REVERSED -> Surface.ROTATION_270
+    }
+
+    companion object {
+        fun fromId(id: String): StreamOrientation =
+            entries.firstOrNull { it.id == id } ?: AUTO
+    }
+}

--- a/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
@@ -114,6 +114,11 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
     // Local rotation provider (we register our own to avoid calling StreamerService.onCreate)
     private var localRotationProvider: IRotationProvider? = null
     private var localRotationListener: IRotationProvider.Listener? = null
+
+    // Cached stream orientation setting — updated from DataStore flow on each change
+    @Volatile
+    private var cachedStreamOrientation: com.dimadesu.lifestreamer.models.StreamOrientation =
+        com.dimadesu.lifestreamer.models.StreamOrientation.AUTO
     
     // Audio passthrough manager for monitoring microphone input (lazy init after context available)
     private val audioPassthroughManager by lazy { 
@@ -289,6 +294,11 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
                             Log.i(TAG, "SENSOR: Ignoring rotation change to ${rotationToString(rotation)} - LOCKED to ${rotationToString(lockedStreamRotation!!)}")
                             return
                         }
+                        // If a fixed orientation is configured, sensor changes don't apply
+                        if (cachedStreamOrientation.toSurfaceRotation() != null) {
+                            Log.i(TAG, "SENSOR: Ignoring rotation change to ${rotationToString(rotation)} - fixed orientation setting active")
+                            return
+                        }
                         Log.i(TAG, "SENSOR: Rotation changed to ${rotationToString(rotation)} - NOT LOCKED, applying")
                         
                         // When not streaming, update rotation normally
@@ -361,6 +371,22 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
                 }
         }
         
+        // Keep cachedStreamOrientation in sync with DataStore; apply fixed rotation immediately
+        serviceScope.launch {
+            storageRepository.streamOrientationFlow.collect { orientation ->
+                cachedStreamOrientation = orientation
+                Log.i(TAG, "Stream orientation setting updated: $orientation")
+                val fixedRotation = orientation.toSurfaceRotation()
+                if (fixedRotation != null && lockedStreamRotation == null) {
+                    try {
+                        (streamer as? IWithVideoRotation)?.setTargetRotation(fixedRotation)
+                        currentRotation = fixedRotation
+                        Log.i(TAG, "Applied fixed orientation to streamer: ${rotationToString(fixedRotation)}")
+                    } catch (_: Throwable) {}
+                }
+            }
+        }
+
         // Observe audio config changes and update passthrough if monitoring is active
         serviceScope.launch {
             storageRepository.audioConfigFlow
@@ -843,10 +869,17 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
         
         if (lockedStreamRotation == null) {
             // First time streaming - detect and save the orientation
-            detectCurrentRotation() // Updates currentRotation variable
+            // If a fixed orientation is configured, use it; otherwise use the current sensor rotation
+            val fixedRotation = cachedStreamOrientation.toSurfaceRotation()
+            if (fixedRotation != null) {
+                currentRotation = fixedRotation
+                Log.i(TAG, "onStreamingStart: INITIAL START - Using fixed orientation setting ${rotationToString(fixedRotation)}")
+            } else {
+                detectCurrentRotation() // Updates currentRotation variable
+            }
             lockedStreamRotation = currentRotation
             savedStreamingOrientation = currentRotation
-            Log.i(TAG, "onStreamingStart: INITIAL START - Detected and locked to ${rotationToString(currentRotation)}, saved for reconnection")
+            Log.i(TAG, "onStreamingStart: INITIAL START - Locked to ${rotationToString(currentRotation)}, saved for reconnection")
         } else if (savedStreamingOrientation != null) {
             // Reconnection - restore the saved orientation
             lockedStreamRotation = savedStreamingOrientation
@@ -1040,8 +1073,13 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
     private suspend fun startStreamFromConfiguredEndpoint() {
         try {
             // Lock stream rotation BEFORE starting to ensure consistent orientation
-            // Detect current rotation and lock to it (same as PreviewViewModel.startStream())
-            detectCurrentRotation()
+            val fixedRotation = cachedStreamOrientation.toSurfaceRotation()
+            if (fixedRotation != null) {
+                currentRotation = fixedRotation
+                Log.i(TAG, "startStreamFromConfiguredEndpoint: Using fixed orientation setting ${rotationToString(fixedRotation)}")
+            } else {
+                detectCurrentRotation()
+            }
             lockStreamRotation(currentRotation)
             Log.i(TAG, "startStreamFromConfiguredEndpoint: Pre-locked stream rotation to ${rotationToString(currentRotation)}")
             

--- a/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
@@ -619,6 +619,21 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
         lockedStreamRotation = rotation
         savedStreamingOrientation = rotation  // Save for reconnection
         currentRotation = rotation
+        
+        // Apply the rotation to the underlying streamer so it encodes in the correct orientation
+        try {
+            serviceScope.launch {
+                try {
+                    (streamer as? IWithVideoRotation)?.setTargetRotation(rotation)
+                    Log.d(TAG, "lockStreamRotation: applied setTargetRotation(${rotationToString(rotation)}) to streamer")
+                } catch (t: Throwable) {
+                    Log.w(TAG, "lockStreamRotation: failed to setTargetRotation", t)
+                }
+            }
+        } catch (t: Throwable) {
+            Log.w(TAG, "lockStreamRotation: failed to setTargetRotation", t)
+        }
+        
         Log.i(TAG, "lockStreamRotation: Setting lock from ${if (wasLocked != null) rotationToString(wasLocked) else "null"} to ${rotationToString(rotation)}, saved for reconnection")
     }
     

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -582,44 +582,34 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
      * Logs appropriate message if orientation is already saved.
      */
     private fun shouldLockOrientation(context: String): Boolean {
-        val savedRotation = previewViewModel.service?.getSavedStreamingOrientation()
+        val savedStreamRotation = previewViewModel.service?.getSavedStreamingOrientation()
         
-        // If Service has saved orientation but Fragment doesn't have it yet, restore UI now
-        if (savedRotation != null && rememberedLockedOrientation == null) {
-            val orientation = when (savedRotation) {
-                android.view.Surface.ROTATION_0 -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-                android.view.Surface.ROTATION_90 -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
-                android.view.Surface.ROTATION_180 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
-                android.view.Surface.ROTATION_270 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
-                else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-            }
+        // If Service has saved orientation but Fragment doesn't have it yet, restore UI lock now
+        if (savedStreamRotation != null && rememberedLockedOrientation == null) {
+            val (orientation, label) = uiOrientationCycle[uiOrientationIndex]
             requireActivity().requestedOrientation = orientation
             rememberedLockedOrientation = orientation
-            rememberedRotation = savedRotation
-            Log.d(TAG, "$context: Restored UI orientation from Service saved rotation: $orientation (rotation: $savedRotation)")
+            Log.d(TAG, "$context: Restored UI lock from button state during reconnection: $label")
             return false // Already handled, don't call lockOrientation()
         }
         
-        return if (savedRotation == null && rememberedLockedOrientation == null) {
+        return if (savedStreamRotation == null && rememberedLockedOrientation == null) {
             true // No saved orientation, proceed with lock
         } else {
-            Log.d(TAG, "$context: Already have saved orientation (Service: $savedRotation, Fragment: $rememberedLockedOrientation), not re-locking")
+            Log.d(TAG, "$context: Already have saved orientation (Service: $savedStreamRotation, Fragment: $rememberedLockedOrientation), not re-locking")
             false
         }
     }
 
     private fun lockOrientation() {
-        // If a fixed orientation is set, use that; otherwise lock to current sensor rotation.
-        val fixedRotation = previewViewModel.streamOrientationFlow.value.toSurfaceRotation()
-        val rotation = if (fixedRotation != null) {
-            fixedRotation
-        } else if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+        // UI Rotation strictly follows the current physical rotation (or what the button forced)
+        val uiRotation = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
             requireContext().display?.rotation ?: android.view.Surface.ROTATION_0
         } else {
             @Suppress("DEPRECATION")
             requireActivity().windowManager.defaultDisplay.rotation
         }
-        val currentOrientation = when (rotation) {
+        val currentOrientation = when (uiRotation) {
             android.view.Surface.ROTATION_0 -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
             android.view.Surface.ROTATION_90 -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
             android.view.Surface.ROTATION_180 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
@@ -627,34 +617,27 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
             else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         }
 
+        // Lock the UI to its current state (so it doesn't spin wildly during the stream)
         rememberedLockedOrientation = currentOrientation
-        rememberedRotation = rotation
+        rememberedRotation = uiRotation
         requireActivity().requestedOrientation = currentOrientation
-        Log.d(TAG, "Orientation locked to: $currentOrientation (rotation: $rotation)")
+        Log.d(TAG, "UI Orientation locked to: $currentOrientation (rotation: $uiRotation)")
 
-        previewViewModel.service?.lockStreamRotation(rotation)
+        // Stream Rotation strictly follows the Settings Menu (fallback to UI rotation if Auto)
+        val fixedStreamRotation = previewViewModel.streamOrientationFlow.value.toSurfaceRotation()
+        val streamRotationToLock = fixedStreamRotation ?: uiRotation
+        
+        previewViewModel.service?.lockStreamRotation(streamRotationToLock)
+        Log.d(TAG, "Stream Orientation locked to: $streamRotationToLock")
     }
 
     private fun unlockOrientation() {
         rememberedLockedOrientation = null
         rememberedRotation = null
-        // When a fixed orientation is configured, keep the activity locked to it after
-        // streaming stops — don't revert to free sensor rotation.
-        val fixedRotation = previewViewModel.streamOrientationFlow.value.toSurfaceRotation()
-        if (fixedRotation != null) {
-            val fixedActivityOrientation = when (fixedRotation) {
-                android.view.Surface.ROTATION_0 -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-                android.view.Surface.ROTATION_90 -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
-                android.view.Surface.ROTATION_180 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
-                android.view.Surface.ROTATION_270 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
-                else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-            }
-            requireActivity().requestedOrientation = fixedActivityOrientation
-            Log.d(TAG, "Orientation kept at fixed setting: $fixedActivityOrientation after stream stop")
-        } else {
-            requireActivity().requestedOrientation = ApplicationConstants.supportedOrientation
-            Log.d(TAG, "Orientation unlocked and remembered orientation cleared")
-        }
+        // Revert UI to whatever the button's state is
+        val (orientation, label) = uiOrientationCycle[uiOrientationIndex]
+        requireActivity().requestedOrientation = orientation
+        Log.d(TAG, "Orientation unlocked, returning to button state: $label")
     }
 
     /**
@@ -780,20 +763,14 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
         } ?: false
         
         if (isInStreamingProcess) {
-            // Get saved orientation from Service (source of truth)
+            // Get saved orientation from Service (source of truth for stream)
             val savedRotation = previewViewModel.service?.getSavedStreamingOrientation()
             if (savedRotation != null) {
-                val orientation = when (savedRotation) {
-                    android.view.Surface.ROTATION_0 -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-                    android.view.Surface.ROTATION_90 -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
-                    android.view.Surface.ROTATION_180 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
-                    android.view.Surface.ROTATION_270 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
-                    else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-                }
+                // Restore UI orientation based solely on button state
+                val (orientation, label) = uiOrientationCycle[uiOrientationIndex]
                 requireActivity().requestedOrientation = orientation
                 rememberedLockedOrientation = orientation
-                rememberedRotation = savedRotation
-                Log.d(TAG, "onStart: Restored orientation from Service: $orientation (rotation: $savedRotation)")
+                Log.d(TAG, "onStart: Restored UI orientation from button state: $label")
             } else {
                 Log.d(TAG, "onStart: No saved orientation in Service, will lock in observer")
             }
@@ -847,22 +824,14 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
             syncButtonState(currentStatus)
             
             if (isInStreamingProcess) {
-                Log.d(TAG, "onResume: Secondary check - restoring orientation from Service (status: $currentStatus)")
+                Log.d(TAG, "onResume: Secondary check - restoring orientation (status: $currentStatus)")
                 
-                // Get saved rotation from Service (survives Fragment lifecycle)
                 val savedRotation = previewViewModel.service?.getSavedStreamingOrientation()
                 if (savedRotation != null) {
-                    val orientation = when (savedRotation) {
-                        android.view.Surface.ROTATION_0 -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-                        android.view.Surface.ROTATION_90 -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
-                        android.view.Surface.ROTATION_180 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
-                        android.view.Surface.ROTATION_270 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
-                        else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-                    }
+                    val (orientation, label) = uiOrientationCycle[uiOrientationIndex]
                     requireActivity().requestedOrientation = orientation
                     rememberedLockedOrientation = orientation
-                    rememberedRotation = savedRotation
-                    Log.d(TAG, "Restored orientation from Service: $orientation (rotation: $savedRotation)")
+                    Log.d(TAG, "onResume: Restored UI orientation from button state: $label")
                 } else {
                     // Fallback to locking current orientation if we don't have a saved one
                     lockOrientation()

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -51,6 +51,7 @@ import androidx.lifecycle.lifecycleScope
 import com.dimadesu.lifestreamer.ApplicationConstants
 import com.dimadesu.lifestreamer.R
 import com.dimadesu.lifestreamer.databinding.MainFragmentBinding
+import com.dimadesu.lifestreamer.models.StreamOrientation
 import com.dimadesu.lifestreamer.models.StreamStatus
 import com.dimadesu.lifestreamer.utils.DialogUtils
 import com.dimadesu.lifestreamer.utils.PermissionManager
@@ -397,6 +398,34 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
             }
         }
 
+        // Apply orientation setting changes in real-time when not streaming
+        lifecycleScope.launch {
+            previewViewModel.streamOrientationFlow.collect { orientation ->
+                val isStreaming = previewViewModel.streamStatus.value.let { status ->
+                    status == com.dimadesu.lifestreamer.models.StreamStatus.STARTING ||
+                    status == com.dimadesu.lifestreamer.models.StreamStatus.CONNECTING ||
+                    status == com.dimadesu.lifestreamer.models.StreamStatus.STREAMING
+                }
+                if (!isStreaming) {
+                    val fixedRotation = orientation.toSurfaceRotation()
+                    if (fixedRotation != null) {
+                        val activityOrientation = when (fixedRotation) {
+                            android.view.Surface.ROTATION_0 -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+                            android.view.Surface.ROTATION_90 -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+                            android.view.Surface.ROTATION_180 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
+                            android.view.Surface.ROTATION_270 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
+                            else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+                        }
+                        requireActivity().requestedOrientation = activityOrientation
+                        Log.d(TAG, "Orientation setting changed to $orientation, applied: $activityOrientation")
+                    } else {
+                        requireActivity().requestedOrientation = ApplicationConstants.supportedOrientation
+                        Log.d(TAG, "Orientation setting changed to Auto, unlocked")
+                    }
+                }
+            }
+        }
+
         previewViewModel.streamerLiveData.observe(viewLifecycleOwner) { streamer ->
             if (streamer is IStreamer) {
                 // TODO: For background streaming, we don't want to automatically stop streaming
@@ -560,17 +589,11 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
     }
 
     private fun lockOrientation() {
-        /**
-         * Lock orientation to current position while streaming to prevent disorienting
-         * rotations mid-stream. The user can choose their preferred orientation before
-         * starting the stream (UI follows sensor via ApplicationConstants.supportedOrientation),
-         * and it will stay locked to that orientation until streaming stops.
-         * 
-         * We remember the current orientation first, then lock to it. This allows us to
-         * restore the exact same orientation if the app goes to background and returns.
-         */
-        // Get the actual current orientation from the display
-        val rotation = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+        // If a fixed orientation is set, use that; otherwise lock to current sensor rotation.
+        val fixedRotation = previewViewModel.streamOrientationFlow.value.toSurfaceRotation()
+        val rotation = if (fixedRotation != null) {
+            fixedRotation
+        } else if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
             requireContext().display?.rotation ?: android.view.Surface.ROTATION_0
         } else {
             @Suppress("DEPRECATION")
@@ -583,26 +606,35 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
             android.view.Surface.ROTATION_270 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
             else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         }
-        
+
         rememberedLockedOrientation = currentOrientation
-        rememberedRotation = rotation  // Store the rotation value too
+        rememberedRotation = rotation
         requireActivity().requestedOrientation = currentOrientation
         Log.d(TAG, "Orientation locked to: $currentOrientation (rotation: $rotation)")
-        
-        // Also lock the stream rotation in the service to match the UI orientation
+
         previewViewModel.service?.lockStreamRotation(rotation)
     }
 
     private fun unlockOrientation() {
-        /**
-         * Unlock orientation after streaming stops, returning to sensor-based rotation.
-         * This allows the user to freely rotate the device and choose a new orientation
-         * for the next stream.
-         */
         rememberedLockedOrientation = null
-        rememberedRotation = null  // Clear rotation too
-        requireActivity().requestedOrientation = ApplicationConstants.supportedOrientation
-        Log.d(TAG, "Orientation unlocked and remembered orientation cleared")
+        rememberedRotation = null
+        // When a fixed orientation is configured, keep the activity locked to it after
+        // streaming stops — don't revert to free sensor rotation.
+        val fixedRotation = previewViewModel.streamOrientationFlow.value.toSurfaceRotation()
+        if (fixedRotation != null) {
+            val fixedActivityOrientation = when (fixedRotation) {
+                android.view.Surface.ROTATION_0 -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+                android.view.Surface.ROTATION_90 -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+                android.view.Surface.ROTATION_180 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
+                android.view.Surface.ROTATION_270 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
+                else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+            }
+            requireActivity().requestedOrientation = fixedActivityOrientation
+            Log.d(TAG, "Orientation kept at fixed setting: $fixedActivityOrientation after stream stop")
+        } else {
+            requireActivity().requestedOrientation = ApplicationConstants.supportedOrientation
+            Log.d(TAG, "Orientation unlocked and remembered orientation cleared")
+        }
     }
 
     /**
@@ -828,12 +860,26 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
                     }
                 }
             } else {
-                Log.d(TAG, "App returned to foreground - not streaming, ensuring orientation unlocked")
-                // Not streaming - ensure orientation is unlocked
-                // This handles the case where stream was stopped from notification while app was in background
+                Log.d(TAG, "App returned to foreground - not streaming, applying orientation setting")
+                // Not streaming - apply orientation setting (unlock for Auto, keep fixed for others)
+                // This also handles the case where stream was stopped from notification while app was in background
                 if (rememberedLockedOrientation != null) {
-                    unlockOrientation()
-                    Log.d(TAG, "Unlocked orientation that was locked from previous streaming session")
+                    unlockOrientation() // respects fixed setting internally
+                    Log.d(TAG, "Applied orientation after stream stop")
+                } else {
+                    // Apply fixed orientation even if we were never locked (e.g. fresh resume)
+                    val fixedRotation = previewViewModel.streamOrientationFlow.value.toSurfaceRotation()
+                    if (fixedRotation != null) {
+                        val fixedActivityOrientation = when (fixedRotation) {
+                            android.view.Surface.ROTATION_0 -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+                            android.view.Surface.ROTATION_90 -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+                            android.view.Surface.ROTATION_180 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
+                            android.view.Surface.ROTATION_270 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
+                            else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+                        }
+                        requireActivity().requestedOrientation = fixedActivityOrientation
+                        Log.d(TAG, "Applied fixed orientation setting on resume: $fixedActivityOrientation")
+                    }
                 }
                 // Start preview immediately
                 try {

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -878,19 +878,8 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
                     unlockOrientation() // respects fixed setting internally
                     Log.d(TAG, "Applied orientation after stream stop")
                 } else {
-                    // Apply fixed orientation even if we were never locked (e.g. fresh resume)
-                    val fixedRotation = previewViewModel.streamOrientationFlow.value.toSurfaceRotation()
-                    if (fixedRotation != null) {
-                        val fixedActivityOrientation = when (fixedRotation) {
-                            android.view.Surface.ROTATION_0 -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-                            android.view.Surface.ROTATION_90 -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
-                            android.view.Surface.ROTATION_180 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
-                            android.view.Surface.ROTATION_270 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
-                            else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-                        }
-                        requireActivity().requestedOrientation = fixedActivityOrientation
-                        Log.d(TAG, "Applied fixed orientation setting on resume: $fixedActivityOrientation")
-                    }
+                    // Do nothing on fresh resume - the viewOrientationSettingFlow observer will handle restoring
+                    // the user's preferred View button orientation automatically.
                 }
                 // Start preview immediately
                 try {

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -47,7 +47,9 @@ import androidx.annotation.RequiresPermission
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.dimadesu.lifestreamer.ApplicationConstants
 import com.dimadesu.lifestreamer.R
 import com.dimadesu.lifestreamer.databinding.MainFragmentBinding
@@ -236,6 +238,26 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
             requireActivity().requestedOrientation = orientation
             binding.previewRotationButton.text = "VIEW: $label"
             Log.d(TAG, "UI orientation override set to $label ($orientation)")
+            
+            // Persist the selected view orientation
+            previewViewModel.saveViewOrientationSetting(orientation)
+        }
+
+        // Observe persisted view orientation setting and restore it
+        lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                previewViewModel.viewOrientationSettingFlow.collect { savedOrientation ->
+                    // Find the matching index in our cycle array
+                    val index = uiOrientationCycle.indexOfFirst { it.first == savedOrientation }
+                    if (index >= 0 && uiOrientationIndex != index) {
+                        uiOrientationIndex = index
+                        val (orientation, label) = uiOrientationCycle[uiOrientationIndex]
+                        requireActivity().requestedOrientation = orientation
+                        binding.previewRotationButton.text = "VIEW: $label"
+                        Log.d(TAG, "Restored UI orientation to $label ($orientation)")
+                    }
+                }
+            }
         }
 
         previewViewModel.isSrtlaStatsVisible.observe(viewLifecycleOwner) { visible ->

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -77,6 +77,18 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
     private var rememberedLockedOrientation: Int? = null
     private var rememberedRotation: Int? = null
 
+    // Manual override of the whole-app (Activity) orientation, cycled via the preview button.
+    // AUTO = follow the sensor (ApplicationConstants.supportedOrientation); other values force
+    // the entire UI (preview + controls) to that orientation, overriding the sensor.
+    private val uiOrientationCycle = listOf<Pair<Int, String>>(
+        ApplicationConstants.supportedOrientation to "AUTO",
+        ActivityInfo.SCREEN_ORIENTATION_PORTRAIT to "PORTRAIT",
+        ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE to "LANDSCAPE",
+        ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT to "PORT REV",
+        ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE to "LAND REV"
+    )
+    private var uiOrientationIndex = 0
+
     // MediaProjection permission launcher - connects to MediaProjectionHelper
     private lateinit var mediaProjectionLauncher: ActivityResultLauncher<Intent>
     // BLUETOOTH_CONNECT permission launcher
@@ -216,6 +228,14 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
 
         binding.srtlaStatsButton.setOnClickListener {
             previewViewModel.setSrtlaStatsVisible(binding.srtlaStatsScrollView.visibility != View.VISIBLE)
+        }
+
+        binding.previewRotationButton.setOnClickListener {
+            uiOrientationIndex = (uiOrientationIndex + 1) % uiOrientationCycle.size
+            val (orientation, label) = uiOrientationCycle[uiOrientationIndex]
+            requireActivity().requestedOrientation = orientation
+            binding.previewRotationButton.text = "VIEW: $label"
+            Log.d(TAG, "UI orientation override set to $label ($orientation)")
         }
 
         previewViewModel.isSrtlaStatsVisible.observe(viewLifecycleOwner) { visible ->

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -74,10 +74,7 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
         PreviewViewModelFactory(requireActivity().application)
     }
 
-    // Remember the orientation AND rotation that was locked when streaming started
-    // This allows us to restore the exact same orientation when returning from background
-    private var rememberedLockedOrientation: Int? = null
-    private var rememberedRotation: Int? = null
+    // No longer remembering locked UI orientation because the View button DataStore handles UI orientation exclusively.
 
     // Manual override of the whole-app (Activity) orientation, cycled via the preview button.
     // AUTO = follow the sensor (ApplicationConstants.supportedOrientation); other values force
@@ -249,7 +246,7 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
                 previewViewModel.viewOrientationSettingFlow.collect { savedOrientation ->
                     // Find the matching index in our cycle array
                     val index = uiOrientationCycle.indexOfFirst { it.first == savedOrientation }
-                    if (index >= 0 && uiOrientationIndex != index) {
+                    if (index >= 0) {
                         uiOrientationIndex = index
                         val (orientation, label) = uiOrientationCycle[uiOrientationIndex]
                         requireActivity().requestedOrientation = orientation
@@ -349,15 +346,7 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
                     lockOrientation()
                 }
             } else {
-                // Only unlock if we're truly stopped AND not reconnecting
-                val shouldStayLocked = currentStatus == com.dimadesu.lifestreamer.models.StreamStatus.STARTING ||
-                                      currentStatus == com.dimadesu.lifestreamer.models.StreamStatus.CONNECTING ||
-                                      isReconnecting
-                if (!shouldStayLocked) {
-                    unlockOrientation()
-                } else {
-                    Log.d(TAG, "Keeping orientation locked - status: $currentStatus, reconnecting: $isReconnecting")
-                }
+                // Stream stopped. UI orientation manages itself via the View button DataStore.
             }
         }
         
@@ -383,13 +372,7 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
                     }
                     com.dimadesu.lifestreamer.models.StreamStatus.NOT_STREAMING,
                     com.dimadesu.lifestreamer.models.StreamStatus.ERROR -> {
-                        // Unlock orientation only when truly stopped and not reconnecting
-                        val isReconnecting = previewViewModel.isReconnectingLiveData.value ?: false
-                        if (previewViewModel.isStreamingLiveData.value == false && !isReconnecting) {
-                            unlockOrientation()
-                        } else {
-                            Log.d(TAG, "Keeping lock despite $status - streaming: ${previewViewModel.isStreamingLiveData.value}, reconnecting: $isReconnecting")
-                        }
+                        // Stream stopped. UI orientation manages itself via the View button DataStore.
                     }
                     com.dimadesu.lifestreamer.models.StreamStatus.STREAMING -> {
                         // Orientation should already be locked by isStreamingLiveData observer
@@ -440,33 +423,8 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
             }
         }
 
-        // Apply orientation setting changes in real-time when not streaming
-        lifecycleScope.launch {
-            previewViewModel.streamOrientationFlow.collect { orientation ->
-                val isStreaming = previewViewModel.streamStatus.value.let { status ->
-                    status == com.dimadesu.lifestreamer.models.StreamStatus.STARTING ||
-                    status == com.dimadesu.lifestreamer.models.StreamStatus.CONNECTING ||
-                    status == com.dimadesu.lifestreamer.models.StreamStatus.STREAMING
-                }
-                if (!isStreaming) {
-                    val fixedRotation = orientation.toSurfaceRotation()
-                    if (fixedRotation != null) {
-                        val activityOrientation = when (fixedRotation) {
-                            android.view.Surface.ROTATION_0 -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-                            android.view.Surface.ROTATION_90 -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
-                            android.view.Surface.ROTATION_180 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
-                            android.view.Surface.ROTATION_270 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
-                            else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-                        }
-                        requireActivity().requestedOrientation = activityOrientation
-                        Log.d(TAG, "Orientation setting changed to $orientation, applied: $activityOrientation")
-                    } else {
-                        requireActivity().requestedOrientation = ApplicationConstants.supportedOrientation
-                        Log.d(TAG, "Orientation setting changed to Auto, unlocked")
-                    }
-                }
-            }
-        }
+        // streamOrientationFlow is no longer observed here for UI orientation changes, 
+        // as the local UI preview orientation is now strictly driven by the viewOrientationSettingFlow.
 
         previewViewModel.streamerLiveData.observe(viewLifecycleOwner) { streamer ->
             if (streamer is IStreamer) {
@@ -598,68 +556,35 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
     }
 
     /**
-     * Helper to check if we should lock orientation for a NEW stream.
-     * Returns true if orientation should be locked (no saved state exists).
-     * If Service has a saved orientation but Fragment doesn't, restores UI to match Service.
-     * Logs appropriate message if orientation is already saved.
+     * Helper to check if we should lock stream orientation for a NEW stream.
+     * Returns true if stream orientation should be locked (no saved state exists in service).
      */
     private fun shouldLockOrientation(context: String): Boolean {
         val savedStreamRotation = previewViewModel.service?.getSavedStreamingOrientation()
         
-        // If Service has saved orientation but Fragment doesn't have it yet, restore UI lock now
-        if (savedStreamRotation != null && rememberedLockedOrientation == null) {
-            val (orientation, label) = uiOrientationCycle[uiOrientationIndex]
-            requireActivity().requestedOrientation = orientation
-            rememberedLockedOrientation = orientation
-            Log.d(TAG, "$context: Restored UI lock from button state during reconnection: $label")
-            return false // Already handled, don't call lockOrientation()
-        }
-        
-        return if (savedStreamRotation == null && rememberedLockedOrientation == null) {
-            true // No saved orientation, proceed with lock
+        return if (savedStreamRotation == null) {
+            true // No saved stream orientation, proceed with lock
         } else {
-            Log.d(TAG, "$context: Already have saved orientation (Service: $savedStreamRotation, Fragment: $rememberedLockedOrientation), not re-locking")
+            Log.d(TAG, "$context: Already have saved stream orientation (Service: $savedStreamRotation), not re-locking")
             false
         }
     }
 
     private fun lockOrientation() {
-        // UI Rotation strictly follows the current physical rotation (or what the button forced)
+        // Find current physical rotation for fallback
         val uiRotation = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
             requireContext().display?.rotation ?: android.view.Surface.ROTATION_0
         } else {
             @Suppress("DEPRECATION")
             requireActivity().windowManager.defaultDisplay.rotation
         }
-        val currentOrientation = when (uiRotation) {
-            android.view.Surface.ROTATION_0 -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-            android.view.Surface.ROTATION_90 -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
-            android.view.Surface.ROTATION_180 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
-            android.view.Surface.ROTATION_270 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
-            else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        }
 
-        // Lock the UI to its current state (so it doesn't spin wildly during the stream)
-        rememberedLockedOrientation = currentOrientation
-        rememberedRotation = uiRotation
-        requireActivity().requestedOrientation = currentOrientation
-        Log.d(TAG, "UI Orientation locked to: $currentOrientation (rotation: $uiRotation)")
-
-        // Stream Rotation strictly follows the Settings Menu (fallback to UI rotation if Auto)
+        // Stream Rotation strictly follows the Settings Menu (fallback to physical rotation if Auto)
         val fixedStreamRotation = previewViewModel.streamOrientationFlow.value.toSurfaceRotation()
         val streamRotationToLock = fixedStreamRotation ?: uiRotation
         
         previewViewModel.service?.lockStreamRotation(streamRotationToLock)
         Log.d(TAG, "Stream Orientation locked to: $streamRotationToLock")
-    }
-
-    private fun unlockOrientation() {
-        rememberedLockedOrientation = null
-        rememberedRotation = null
-        // Revert UI to whatever the button's state is
-        val (orientation, label) = uiOrientationCycle[uiOrientationIndex]
-        requireActivity().requestedOrientation = orientation
-        Log.d(TAG, "Orientation unlocked, returning to button state: $label")
     }
 
     /**
@@ -786,16 +711,7 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
         
         if (isInStreamingProcess) {
             // Get saved orientation from Service (source of truth for stream)
-            val savedRotation = previewViewModel.service?.getSavedStreamingOrientation()
-            if (savedRotation != null) {
-                // Restore UI orientation based solely on button state
-                val (orientation, label) = uiOrientationCycle[uiOrientationIndex]
-                requireActivity().requestedOrientation = orientation
-                rememberedLockedOrientation = orientation
-                Log.d(TAG, "onStart: Restored UI orientation from button state: $label")
-            } else {
-                Log.d(TAG, "onStart: No saved orientation in Service, will lock in observer")
-            }
+            Log.d(TAG, "onStart: Stream running, UI orientation handles itself via DataStore flow")
         }
         
         // NOTE: Permission request moved to onResume() to fix preview freeze when quickly
@@ -849,15 +765,10 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
                 Log.d(TAG, "onResume: Secondary check - restoring orientation (status: $currentStatus)")
                 
                 val savedRotation = previewViewModel.service?.getSavedStreamingOrientation()
-                if (savedRotation != null) {
-                    val (orientation, label) = uiOrientationCycle[uiOrientationIndex]
-                    requireActivity().requestedOrientation = orientation
-                    rememberedLockedOrientation = orientation
-                    Log.d(TAG, "onResume: Restored UI orientation from button state: $label")
-                } else {
-                    // Fallback to locking current orientation if we don't have a saved one
+                if (savedRotation == null) {
+                    // Lock the STREAM orientation since we're starting a new stream
                     lockOrientation()
-                    Log.d(TAG, "No saved orientation in Service, locked to current position")
+                    Log.d(TAG, "onResume: No saved stream orientation in Service, locking stream")
                 }
                 
                 // SECOND: Give the orientation change time to propagate before restarting preview
@@ -874,13 +785,8 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
                 Log.d(TAG, "App returned to foreground - not streaming, applying orientation setting")
                 // Not streaming - apply orientation setting (unlock for Auto, keep fixed for others)
                 // This also handles the case where stream was stopped from notification while app was in background
-                if (rememberedLockedOrientation != null) {
-                    unlockOrientation() // respects fixed setting internally
-                    Log.d(TAG, "Applied orientation after stream stop")
-                } else {
-                    // Do nothing on fresh resume - the viewOrientationSettingFlow observer will handle restoring
-                    // the user's preferred View button orientation automatically.
-                }
+                // Do nothing on fresh resume - the viewOrientationSettingFlow observer will handle restoring
+                // the user's preferred View button orientation automatically.
                 // Start preview immediately
                 try {
                     inflateStreamerPreview()

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -183,6 +183,13 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
     private val _encoderStatsLiveData = MutableLiveData<String?>(null)
     val encoderStatsLiveData: LiveData<String?> get() = _encoderStatsLiveData
 
+    val streamOrientationFlow: StateFlow<com.dimadesu.lifestreamer.models.StreamOrientation> =
+        storageRepository.streamOrientationFlow.stateIn(
+            viewModelScope,
+            SharingStarted.Eagerly,
+            com.dimadesu.lifestreamer.models.StreamOrientation.AUTO
+        )
+
     // Track whether the UI is in foreground (to avoid camera operations when paused)
     @Volatile
     private var isUiInForeground = true

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -190,6 +190,19 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
             com.dimadesu.lifestreamer.models.StreamOrientation.AUTO
         )
 
+    val viewOrientationSettingFlow: StateFlow<Int> =
+        storageRepository.viewOrientationSettingFlow.stateIn(
+            viewModelScope,
+            SharingStarted.Eagerly,
+            android.content.pm.ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+        )
+
+    fun saveViewOrientationSetting(setting: Int) {
+        viewModelScope.launch {
+            storageRepository.saveViewOrientationSetting(setting)
+        }
+    }
+
     // Track whether the UI is in foreground (to avoid camera operations when paused)
     @Volatile
     private var isUiInForeground = true

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -1498,62 +1498,7 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                 }
             }
         }
-        // Apply rotation changes, but if streamer is currently streaming or reconnecting,
-        // queue the change and apply it when streaming stops to avoid conflicts in encoding pipeline.
-        viewModelScope.launch {
-            rotationRepository.rotationFlow.collect { rotation ->
-                val current = serviceStreamer
-                val isCurrentlyStreaming = current?.isStreamingFlow?.value == true
-                val currentStatus = streamStatus.value
-                val isInStreamingProcess = currentStatus == StreamStatus.STARTING ||
-                                           currentStatus == StreamStatus.CONNECTING ||
-                                           currentStatus == StreamStatus.STREAMING
-                
-                // During reconnection, ignore rotation changes to maintain locked orientation
-                // But remember the latest rotation so we can apply it when reconnection ends
-                if (service?.isReconnecting?.value == true) {
-                    rotationIgnoredDuringReconnection = rotation
-                    Log.i(TAG, "Rotation change to $rotation ignored during reconnection (will apply later)")
-                    return@collect
-                }
-                
-                if (isCurrentlyStreaming || isInStreamingProcess) {
-                    Log.i(TAG, "Rotation change to $rotation queued (streaming: $isCurrentlyStreaming, status: $currentStatus)")
-                    pendingTargetRotation = rotation
-                } else {
-                    try {
-                        current?.setTargetRotation(rotation)
-                        Log.i(TAG, "Rotation change to $rotation applied immediately (not streaming)")
-                    } catch (t: Throwable) {
-                        Log.w(TAG, "Failed to set target rotation: $t")
-                    }
-                }
-            }
-        }
-
-        // When streaming stops, apply any pending rotation change.
-        // BUT: Don't apply during reconnection - we want to keep the locked orientation
-        viewModelScope.launch {
-            serviceReadyFlow.collect { isReady ->
-                if (isReady) {
-                    serviceStreamer?.isStreamingFlow?.collect { isStreaming ->
-                        if (!isStreaming && service?.isReconnecting?.value != true) {
-                            pendingTargetRotation?.let { pending ->
-                                Log.i(TAG, "Applying pending rotation $pending after stream stopped")
-                                try {
-                                    serviceStreamer?.setTargetRotation(pending)
-                                } catch (t: Throwable) {
-                                    Log.w(TAG, "Failed to apply pending rotation: $t")
-                                }
-                                pendingTargetRotation = null
-                            }
-                        } else if (!isStreaming && service?.isReconnecting?.value == true) {
-                            Log.i(TAG, "Skipping pending rotation application during reconnection (pending: $pendingTargetRotation)")
-                        }
-                    }
-                }
-            }
-        }
+        // Rotation changes are now handled by CameraStreamerService
         
         // Observe manual stop from notification - cancel reconnection if in progress
         // Use a separate coroutine that waits for service to be ready and then observes the flow
@@ -1728,16 +1673,7 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
             service?.setStreamStatus(StreamStatus.STARTING)
             Log.i(TAG, "startStream() called")
             
-            // Lock stream rotation BEFORE starting to ensure it matches UI orientation
-            // Get current display rotation and lock the service to it
-            // Note: We use WindowManager.defaultDisplay for all API levels here because
-            // Application context doesn't have an associated display. The deprecation
-            // is acceptable since this is just reading the current rotation value.
-            val windowManager = application.getSystemService(Context.WINDOW_SERVICE) as android.view.WindowManager
-            @Suppress("DEPRECATION")
-            val currentRotation = windowManager.defaultDisplay.rotation
-            service?.lockStreamRotation(currentRotation)
-            Log.i(TAG, "Pre-locked stream rotation to $currentRotation before starting")
+            // Stream rotation lock is handled by PreviewFragment before calling startStream()
             
             val currentStreamer = serviceStreamer
             val serviceReady = _serviceReady.value
@@ -2165,18 +2101,7 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                     // Cancel any pending reconnection attempts (already done via service.markUserStoppedManually)
                     reconnectTimer.stop()
                     
-                    // Apply any rotation that was ignored during reconnection
-                    rotationIgnoredDuringReconnection?.let { ignoredRotation ->
-                        viewModelScope.launch {
-                            try {
-                                serviceStreamer?.setTargetRotation(ignoredRotation)
-                                Log.i(TAG, "Applied rotation ($ignoredRotation) that was ignored during reconnection")
-                            } catch (t: Throwable) {
-                                Log.w(TAG, "Failed to apply ignored rotation: $t")
-                            }
-                        }
-                        rotationIgnoredDuringReconnection = null
-                    }
+                    // rotationIgnoredDuringReconnection logic removed
                     
                     // Only set cleanup flag if we didn't take an early exit path
                     // (Early exit paths manage their own cleanup flags)

--- a/app/src/main/res/layout/main_fragment.xml
+++ b/app/src/main/res/layout/main_fragment.xml
@@ -278,6 +278,13 @@
                     android:backgroundTint="@color/button_gray"
                     app:goneUnless="@{viewmodel.isSrtlaEndpoint}" />
 
+                <Button
+                    android:id="@+id/previewRotationButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="VIEW: AUTO"
+                    android:backgroundTint="@color/button_gray" />
+
             </LinearLayout>
 
         </ScrollView>

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -66,4 +66,20 @@
         <!-- <item>9</item> -->
     </string-array>
 
+    <string-array name="stream_orientation_entries">
+        <item>@string/stream_orientation_entry_auto</item>
+        <item>@string/stream_orientation_entry_portrait</item>
+        <item>@string/stream_orientation_entry_landscape</item>
+        <item>@string/stream_orientation_entry_portrait_reversed</item>
+        <item>@string/stream_orientation_entry_landscape_reversed</item>
+    </string-array>
+
+    <string-array name="stream_orientation_values">
+        <item>@string/stream_orientation_value_auto</item>
+        <item>@string/stream_orientation_value_portrait</item>
+        <item>@string/stream_orientation_value_landscape</item>
+        <item>@string/stream_orientation_value_portrait_reversed</item>
+        <item>@string/stream_orientation_value_landscape_reversed</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -361,4 +361,19 @@
     <string name="video_level_high_level62">HighLevel62</string>
     <string name="av_level_unknown">Unknown level</string>
 
+    <!-- Stream orientation setting -->
+    <string name="stream_orientation_key">stream_orientation</string>
+    <string name="stream_orientation_title">Stream orientation</string>
+    <string name="stream_orientation_summary">%s</string>
+    <string name="stream_orientation_value_auto">auto</string>
+    <string name="stream_orientation_value_portrait">portrait</string>
+    <string name="stream_orientation_value_landscape">landscape</string>
+    <string name="stream_orientation_value_portrait_reversed">portrait_reversed</string>
+    <string name="stream_orientation_value_landscape_reversed">landscape_reversed</string>
+    <string name="stream_orientation_entry_auto">Auto (follow device rotation)</string>
+    <string name="stream_orientation_entry_portrait">Portrait</string>
+    <string name="stream_orientation_entry_landscape">Landscape</string>
+    <string name="stream_orientation_entry_portrait_reversed">Portrait (reversed)</string>
+    <string name="stream_orientation_entry_landscape_reversed">Landscape (reversed)</string>
+
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -40,6 +40,15 @@
 
     <PreferenceCategory app:title="@string/video">
 
+        <ListPreference
+            app:key="@string/stream_orientation_key"
+            app:title="@string/stream_orientation_title"
+            app:summary="@string/stream_orientation_summary"
+            app:defaultValue="@string/stream_orientation_value_auto"
+            app:entryValues="@array/stream_orientation_values"
+            app:entries="@array/stream_orientation_entries"
+            app:useSimpleSummaryProvider="true" />
+
         <PreferenceCategory
             app:key="@string/video_settings_key"
             app:title="@string/settings">


### PR DESCRIPTION
Five options: Auto (follows device rotation, existing behavior), Portrait, Landscape, Portrait Reversed, Landscape Reversed. Fixed orientations lock the Activity and stream encoder from app launch, not just during streaming.