### PR TITLE
Add "Stream orientation" to video settings (early version). Lock the stream and main screen orientation to portrait or landscape

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/data/storage/DataStoreRepository.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/data/storage/DataStoreRepository.kt
@@ -344,6 +344,12 @@ class DataStoreRepository(
         }
     }.distinctUntilChanged()
 
+    val streamOrientationFlow: Flow<com.dimadesu.lifestreamer.models.StreamOrientation> = dataStore.data.map { preferences ->
+        val stored = preferences[stringPreferencesKey(context.getString(R.string.stream_orientation_key))]
+            ?: context.getString(R.string.stream_orientation_value_auto)
+        com.dimadesu.lifestreamer.models.StreamOrientation.fromId(stored)
+    }.distinctUntilChanged()
+
     // Save methods for audio settings
     suspend fun saveAudioSourceType(sourceType: Int) {
         dataStore.edit { preferences ->

--- a/app/src/main/java/com/dimadesu/lifestreamer/models/StreamOrientation.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/models/StreamOrientation.kt
@@ -1,0 +1,24 @@
+package com.dimadesu.lifestreamer.models
+
+import android.view.Surface
+
+enum class StreamOrientation(val id: String) {
+    AUTO("auto"),
+    PORTRAIT("portrait"),
+    LANDSCAPE("landscape"),
+    PORTRAIT_REVERSED("portrait_reversed"),
+    LANDSCAPE_REVERSED("landscape_reversed");
+
+    fun toSurfaceRotation(): Int? = when (this) {
+        AUTO -> null
+        PORTRAIT -> Surface.ROTATION_0
+        LANDSCAPE -> Surface.ROTATION_90
+        PORTRAIT_REVERSED -> Surface.ROTATION_180
+        LANDSCAPE_REVERSED -> Surface.ROTATION_270
+    }
+
+    companion object {
+        fun fromId(id: String): StreamOrientation =
+            entries.firstOrNull { it.id == id } ?: AUTO
+    }
+}

--- a/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
@@ -114,6 +114,11 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
     // Local rotation provider (we register our own to avoid calling StreamerService.onCreate)
     private var localRotationProvider: IRotationProvider? = null
     private var localRotationListener: IRotationProvider.Listener? = null
+
+    // Cached stream orientation setting — updated from DataStore flow on each change
+    @Volatile
+    private var cachedStreamOrientation: com.dimadesu.lifestreamer.models.StreamOrientation =
+        com.dimadesu.lifestreamer.models.StreamOrientation.AUTO
     
     // Audio passthrough manager for monitoring microphone input (lazy init after context available)
     private val audioPassthroughManager by lazy { 
@@ -289,6 +294,11 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
                             Log.i(TAG, "SENSOR: Ignoring rotation change to ${rotationToString(rotation)} - LOCKED to ${rotationToString(lockedStreamRotation!!)}")
                             return
                         }
+                        // If a fixed orientation is configured, sensor changes don't apply
+                        if (cachedStreamOrientation.toSurfaceRotation() != null) {
+                            Log.i(TAG, "SENSOR: Ignoring rotation change to ${rotationToString(rotation)} - fixed orientation setting active")
+                            return
+                        }
                         Log.i(TAG, "SENSOR: Rotation changed to ${rotationToString(rotation)} - NOT LOCKED, applying")
                         
                         // When not streaming, update rotation normally
@@ -361,6 +371,22 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
                 }
         }
         
+        // Keep cachedStreamOrientation in sync with DataStore; apply fixed rotation immediately
+        serviceScope.launch {
+            storageRepository.streamOrientationFlow.collect { orientation ->
+                cachedStreamOrientation = orientation
+                Log.i(TAG, "Stream orientation setting updated: $orientation")
+                val fixedRotation = orientation.toSurfaceRotation()
+                if (fixedRotation != null && lockedStreamRotation == null) {
+                    try {
+                        (streamer as? IWithVideoRotation)?.setTargetRotation(fixedRotation)
+                        currentRotation = fixedRotation
+                        Log.i(TAG, "Applied fixed orientation to streamer: ${rotationToString(fixedRotation)}")
+                    } catch (_: Throwable) {}
+                }
+            }
+        }
+
         // Observe audio config changes and update passthrough if monitoring is active
         serviceScope.launch {
             storageRepository.audioConfigFlow
@@ -843,10 +869,17 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
         
         if (lockedStreamRotation == null) {
             // First time streaming - detect and save the orientation
-            detectCurrentRotation() // Updates currentRotation variable
+            // If a fixed orientation is configured, use it; otherwise use the current sensor rotation
+            val fixedRotation = cachedStreamOrientation.toSurfaceRotation()
+            if (fixedRotation != null) {
+                currentRotation = fixedRotation
+                Log.i(TAG, "onStreamingStart: INITIAL START - Using fixed orientation setting ${rotationToString(fixedRotation)}")
+            } else {
+                detectCurrentRotation() // Updates currentRotation variable
+            }
             lockedStreamRotation = currentRotation
             savedStreamingOrientation = currentRotation
-            Log.i(TAG, "onStreamingStart: INITIAL START - Detected and locked to ${rotationToString(currentRotation)}, saved for reconnection")
+            Log.i(TAG, "onStreamingStart: INITIAL START - Locked to ${rotationToString(currentRotation)}, saved for reconnection")
         } else if (savedStreamingOrientation != null) {
             // Reconnection - restore the saved orientation
             lockedStreamRotation = savedStreamingOrientation
@@ -1040,8 +1073,13 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
     private suspend fun startStreamFromConfiguredEndpoint() {
         try {
             // Lock stream rotation BEFORE starting to ensure consistent orientation
-            // Detect current rotation and lock to it (same as PreviewViewModel.startStream())
-            detectCurrentRotation()
+            val fixedRotation = cachedStreamOrientation.toSurfaceRotation()
+            if (fixedRotation != null) {
+                currentRotation = fixedRotation
+                Log.i(TAG, "startStreamFromConfiguredEndpoint: Using fixed orientation setting ${rotationToString(fixedRotation)}")
+            } else {
+                detectCurrentRotation()
+            }
             lockStreamRotation(currentRotation)
             Log.i(TAG, "startStreamFromConfiguredEndpoint: Pre-locked stream rotation to ${rotationToString(currentRotation)}")
             

--- a/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
@@ -930,12 +930,13 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
      */
     private fun detectCurrentRotation() {
         try {
-            val rotation = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                display?.rotation ?: Surface.ROTATION_0
-            } else {
-                @Suppress("DEPRECATION")
-                (getSystemService(Context.WINDOW_SERVICE) as? WindowManager)?.defaultDisplay?.rotation ?: Surface.ROTATION_0
-            }
+            // Using WindowManager explicitly is safer in a Service context because 
+            // Context.display can throw UnsupportedOperationException if the service 
+            // is not explicitly associated with a display.
+            @Suppress("DEPRECATION")
+            val windowManager = getSystemService(Context.WINDOW_SERVICE) as? WindowManager
+            @Suppress("DEPRECATION")
+            val rotation = windowManager?.defaultDisplay?.rotation ?: Surface.ROTATION_0
             
             currentRotation = rotation
             Log.i(TAG, "Detected device rotation: ${rotationToString(rotation)}")

--- a/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
@@ -1077,9 +1077,15 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
             if (fixedRotation != null) {
                 currentRotation = fixedRotation
                 Log.i(TAG, "startStreamFromConfiguredEndpoint: Using fixed orientation setting ${rotationToString(fixedRotation)}")
+            } else if (savedStreamingOrientation != null) {
+                // If we are reconnecting and the setting is AUTO, we must resume in the exact
+                // same orientation we started the stream in to avoid glitching the ingest server.
+                currentRotation = savedStreamingOrientation!!
+                Log.i(TAG, "startStreamFromConfiguredEndpoint: Reconnecting - Restoring saved orientation ${rotationToString(currentRotation)}")
             } else {
                 detectCurrentRotation()
             }
+            
             // Explicitly tell StreamPack's encoder pipeline about the rotation.
             // lockStreamRotation only updates internal tracking variables; without this
             // call the encoder may use a stale targetRotation (e.g. portrait from split-screen).

--- a/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
@@ -1080,6 +1080,15 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
             } else {
                 detectCurrentRotation()
             }
+            // Explicitly tell StreamPack's encoder pipeline about the rotation.
+            // lockStreamRotation only updates internal tracking variables; without this
+            // call the encoder may use a stale targetRotation (e.g. portrait from split-screen).
+            try {
+                (streamer as? IWithVideoRotation)?.setTargetRotation(currentRotation)
+                Log.i(TAG, "startStreamFromConfiguredEndpoint: Applied target rotation ${rotationToString(currentRotation)} to streamer")
+            } catch (t: Throwable) {
+                Log.w(TAG, "startStreamFromConfiguredEndpoint: Failed to set target rotation: ${t.message}")
+            }
             lockStreamRotation(currentRotation)
             Log.i(TAG, "startStreamFromConfiguredEndpoint: Pre-locked stream rotation to ${rotationToString(currentRotation)}")
             

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -51,6 +51,7 @@ import androidx.lifecycle.lifecycleScope
 import com.dimadesu.lifestreamer.ApplicationConstants
 import com.dimadesu.lifestreamer.R
 import com.dimadesu.lifestreamer.databinding.MainFragmentBinding
+import com.dimadesu.lifestreamer.models.StreamOrientation
 import com.dimadesu.lifestreamer.models.StreamStatus
 import com.dimadesu.lifestreamer.utils.DialogUtils
 import com.dimadesu.lifestreamer.utils.PermissionManager
@@ -397,6 +398,34 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
             }
         }
 
+        // Apply orientation setting changes in real-time when not streaming
+        lifecycleScope.launch {
+            previewViewModel.streamOrientationFlow.collect { orientation ->
+                val isStreaming = previewViewModel.streamStatus.value.let { status ->
+                    status == com.dimadesu.lifestreamer.models.StreamStatus.STARTING ||
+                    status == com.dimadesu.lifestreamer.models.StreamStatus.CONNECTING ||
+                    status == com.dimadesu.lifestreamer.models.StreamStatus.STREAMING
+                }
+                if (!isStreaming) {
+                    val fixedRotation = orientation.toSurfaceRotation()
+                    if (fixedRotation != null) {
+                        val activityOrientation = when (fixedRotation) {
+                            android.view.Surface.ROTATION_0 -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+                            android.view.Surface.ROTATION_90 -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+                            android.view.Surface.ROTATION_180 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
+                            android.view.Surface.ROTATION_270 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
+                            else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+                        }
+                        requireActivity().requestedOrientation = activityOrientation
+                        Log.d(TAG, "Orientation setting changed to $orientation, applied: $activityOrientation")
+                    } else {
+                        requireActivity().requestedOrientation = ApplicationConstants.supportedOrientation
+                        Log.d(TAG, "Orientation setting changed to Auto, unlocked")
+                    }
+                }
+            }
+        }
+
         previewViewModel.streamerLiveData.observe(viewLifecycleOwner) { streamer ->
             if (streamer is IStreamer) {
                 // TODO: For background streaming, we don't want to automatically stop streaming
@@ -560,17 +589,11 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
     }
 
     private fun lockOrientation() {
-        /**
-         * Lock orientation to current position while streaming to prevent disorienting
-         * rotations mid-stream. The user can choose their preferred orientation before
-         * starting the stream (UI follows sensor via ApplicationConstants.supportedOrientation),
-         * and it will stay locked to that orientation until streaming stops.
-         * 
-         * We remember the current orientation first, then lock to it. This allows us to
-         * restore the exact same orientation if the app goes to background and returns.
-         */
-        // Get the actual current orientation from the display
-        val rotation = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+        // If a fixed orientation is set, use that; otherwise lock to current sensor rotation.
+        val fixedRotation = previewViewModel.streamOrientationFlow.value.toSurfaceRotation()
+        val rotation = if (fixedRotation != null) {
+            fixedRotation
+        } else if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
             requireContext().display?.rotation ?: android.view.Surface.ROTATION_0
         } else {
             @Suppress("DEPRECATION")
@@ -583,26 +606,35 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
             android.view.Surface.ROTATION_270 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
             else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         }
-        
+
         rememberedLockedOrientation = currentOrientation
-        rememberedRotation = rotation  // Store the rotation value too
+        rememberedRotation = rotation
         requireActivity().requestedOrientation = currentOrientation
         Log.d(TAG, "Orientation locked to: $currentOrientation (rotation: $rotation)")
-        
-        // Also lock the stream rotation in the service to match the UI orientation
+
         previewViewModel.service?.lockStreamRotation(rotation)
     }
 
     private fun unlockOrientation() {
-        /**
-         * Unlock orientation after streaming stops, returning to sensor-based rotation.
-         * This allows the user to freely rotate the device and choose a new orientation
-         * for the next stream.
-         */
         rememberedLockedOrientation = null
-        rememberedRotation = null  // Clear rotation too
-        requireActivity().requestedOrientation = ApplicationConstants.supportedOrientation
-        Log.d(TAG, "Orientation unlocked and remembered orientation cleared")
+        rememberedRotation = null
+        // When a fixed orientation is configured, keep the activity locked to it after
+        // streaming stops — don't revert to free sensor rotation.
+        val fixedRotation = previewViewModel.streamOrientationFlow.value.toSurfaceRotation()
+        if (fixedRotation != null) {
+            val fixedActivityOrientation = when (fixedRotation) {
+                android.view.Surface.ROTATION_0 -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+                android.view.Surface.ROTATION_90 -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+                android.view.Surface.ROTATION_180 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
+                android.view.Surface.ROTATION_270 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
+                else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+            }
+            requireActivity().requestedOrientation = fixedActivityOrientation
+            Log.d(TAG, "Orientation kept at fixed setting: $fixedActivityOrientation after stream stop")
+        } else {
+            requireActivity().requestedOrientation = ApplicationConstants.supportedOrientation
+            Log.d(TAG, "Orientation unlocked and remembered orientation cleared")
+        }
     }
 
     /**
@@ -828,12 +860,26 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
                     }
                 }
             } else {
-                Log.d(TAG, "App returned to foreground - not streaming, ensuring orientation unlocked")
-                // Not streaming - ensure orientation is unlocked
-                // This handles the case where stream was stopped from notification while app was in background
+                Log.d(TAG, "App returned to foreground - not streaming, applying orientation setting")
+                // Not streaming - apply orientation setting (unlock for Auto, keep fixed for others)
+                // This also handles the case where stream was stopped from notification while app was in background
                 if (rememberedLockedOrientation != null) {
-                    unlockOrientation()
-                    Log.d(TAG, "Unlocked orientation that was locked from previous streaming session")
+                    unlockOrientation() // respects fixed setting internally
+                    Log.d(TAG, "Applied orientation after stream stop")
+                } else {
+                    // Apply fixed orientation even if we were never locked (e.g. fresh resume)
+                    val fixedRotation = previewViewModel.streamOrientationFlow.value.toSurfaceRotation()
+                    if (fixedRotation != null) {
+                        val fixedActivityOrientation = when (fixedRotation) {
+                            android.view.Surface.ROTATION_0 -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+                            android.view.Surface.ROTATION_90 -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+                            android.view.Surface.ROTATION_180 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
+                            android.view.Surface.ROTATION_270 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
+                            else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+                        }
+                        requireActivity().requestedOrientation = fixedActivityOrientation
+                        Log.d(TAG, "Applied fixed orientation setting on resume: $fixedActivityOrientation")
+                    }
                 }
                 // Start preview immediately
                 try {

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -409,13 +409,7 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
                 if (!isStreaming) {
                     val fixedRotation = orientation.toSurfaceRotation()
                     if (fixedRotation != null) {
-                        val activityOrientation = when (fixedRotation) {
-                            android.view.Surface.ROTATION_0 -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-                            android.view.Surface.ROTATION_90 -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
-                            android.view.Surface.ROTATION_180 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
-                            android.view.Surface.ROTATION_270 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
-                            else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-                        }
+                        val activityOrientation = fixedRotation.toActivityOrientation()
                         requireActivity().requestedOrientation = activityOrientation
                         Log.d(TAG, "Orientation setting changed to $orientation, applied: $activityOrientation")
                     } else {
@@ -566,13 +560,7 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
         
         // If Service has saved orientation but Fragment doesn't have it yet, restore UI now
         if (savedRotation != null && rememberedLockedOrientation == null) {
-            val orientation = when (savedRotation) {
-                android.view.Surface.ROTATION_0 -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-                android.view.Surface.ROTATION_90 -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
-                android.view.Surface.ROTATION_180 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
-                android.view.Surface.ROTATION_270 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
-                else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-            }
+            val orientation = savedRotation.toActivityOrientation()
             requireActivity().requestedOrientation = orientation
             rememberedLockedOrientation = orientation
             rememberedRotation = savedRotation
@@ -599,13 +587,7 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
             @Suppress("DEPRECATION")
             requireActivity().windowManager.defaultDisplay.rotation
         }
-        val currentOrientation = when (rotation) {
-            android.view.Surface.ROTATION_0 -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-            android.view.Surface.ROTATION_90 -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
-            android.view.Surface.ROTATION_180 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
-            android.view.Surface.ROTATION_270 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
-            else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        }
+        val currentOrientation = rotation.toActivityOrientation()
 
         rememberedLockedOrientation = currentOrientation
         rememberedRotation = rotation
@@ -622,13 +604,7 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
         // streaming stops — don't revert to free sensor rotation.
         val fixedRotation = previewViewModel.streamOrientationFlow.value.toSurfaceRotation()
         if (fixedRotation != null) {
-            val fixedActivityOrientation = when (fixedRotation) {
-                android.view.Surface.ROTATION_0 -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-                android.view.Surface.ROTATION_90 -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
-                android.view.Surface.ROTATION_180 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
-                android.view.Surface.ROTATION_270 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
-                else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-            }
+            val fixedActivityOrientation = fixedRotation.toActivityOrientation()
             requireActivity().requestedOrientation = fixedActivityOrientation
             Log.d(TAG, "Orientation kept at fixed setting: $fixedActivityOrientation after stream stop")
         } else {
@@ -763,13 +739,7 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
             // Get saved orientation from Service (source of truth)
             val savedRotation = previewViewModel.service?.getSavedStreamingOrientation()
             if (savedRotation != null) {
-                val orientation = when (savedRotation) {
-                    android.view.Surface.ROTATION_0 -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-                    android.view.Surface.ROTATION_90 -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
-                    android.view.Surface.ROTATION_180 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
-                    android.view.Surface.ROTATION_270 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
-                    else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-                }
+                val orientation = savedRotation.toActivityOrientation()
                 requireActivity().requestedOrientation = orientation
                 rememberedLockedOrientation = orientation
                 rememberedRotation = savedRotation
@@ -832,13 +802,7 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
                 // Get saved rotation from Service (survives Fragment lifecycle)
                 val savedRotation = previewViewModel.service?.getSavedStreamingOrientation()
                 if (savedRotation != null) {
-                    val orientation = when (savedRotation) {
-                        android.view.Surface.ROTATION_0 -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-                        android.view.Surface.ROTATION_90 -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
-                        android.view.Surface.ROTATION_180 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
-                        android.view.Surface.ROTATION_270 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
-                        else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-                    }
+                    val orientation = savedRotation.toActivityOrientation()
                     requireActivity().requestedOrientation = orientation
                     rememberedLockedOrientation = orientation
                     rememberedRotation = savedRotation
@@ -870,13 +834,7 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
                     // Apply fixed orientation even if we were never locked (e.g. fresh resume)
                     val fixedRotation = previewViewModel.streamOrientationFlow.value.toSurfaceRotation()
                     if (fixedRotation != null) {
-                        val fixedActivityOrientation = when (fixedRotation) {
-                            android.view.Surface.ROTATION_0 -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-                            android.view.Surface.ROTATION_90 -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
-                            android.view.Surface.ROTATION_180 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
-                            android.view.Surface.ROTATION_270 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
-                            else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-                        }
+                        val fixedActivityOrientation = fixedRotation.toActivityOrientation()
                         requireActivity().requestedOrientation = fixedActivityOrientation
                         Log.d(TAG, "Applied fixed orientation setting on resume: $fixedActivityOrientation")
                     }
@@ -1320,4 +1278,13 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
     companion object {
         private const val TAG = "PreviewFragment"
     }
+
+    private fun Int.toActivityOrientation(): Int = when (this) {
+        android.view.Surface.ROTATION_0 -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        android.view.Surface.ROTATION_90 -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+        android.view.Surface.ROTATION_180 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
+        android.view.Surface.ROTATION_270 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
+        else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    }
+
 }

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -82,6 +82,7 @@ import io.github.thibaultbee.streampack.core.elements.sources.video.bitmap.Bitma
 import io.github.thibaultbee.streampack.core.streamers.single.VideoConfig
 import io.github.thibaultbee.streampack.core.streamers.single.AudioConfig
 import com.dimadesu.lifestreamer.services.CameraStreamerService
+import io.github.thibaultbee.streampack.core.interfaces.IWithVideoRotation
 import com.dimadesu.lifestreamer.bitrate.AdaptiveSrtBitrateRegulatorController
 import com.dimadesu.lifestreamer.models.StreamStatus
 import com.dimadesu.lifestreamer.srtla.SrtlaManager
@@ -1728,14 +1729,26 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
             service?.setStreamStatus(StreamStatus.STARTING)
             Log.i(TAG, "startStream() called")
             
-            // Lock stream rotation BEFORE starting to ensure it matches UI orientation
-            // Get current display rotation and lock the service to it
-            // Note: We use WindowManager.defaultDisplay for all API levels here because
-            // Application context doesn't have an associated display. The deprecation
-            // is acceptable since this is just reading the current rotation value.
-            val windowManager = application.getSystemService(Context.WINDOW_SERVICE) as android.view.WindowManager
-            @Suppress("DEPRECATION")
-            val currentRotation = windowManager.defaultDisplay.rotation
+            // Lock stream rotation BEFORE starting to ensure it matches the user's
+            // orientation preference.  If a fixed orientation is configured, honour it
+            // instead of blindly reading the display (which in split-screen is always portrait).
+            val fixedRotation = streamOrientationFlow.value.toSurfaceRotation()
+            val currentRotation = if (fixedRotation != null) {
+                Log.i(TAG, "Using fixed stream orientation setting: ${streamOrientationFlow.value}")
+                fixedRotation
+            } else {
+                val windowManager = application.getSystemService(Context.WINDOW_SERVICE) as android.view.WindowManager
+                @Suppress("DEPRECATION")
+                val displayRotation = windowManager.defaultDisplay.rotation
+                Log.i(TAG, "Using display rotation (AUTO): $displayRotation")
+                displayRotation
+            }
+            // Tell StreamPack's encoder about the rotation so it builds the correct dimensions
+            try {
+                (serviceStreamer as? IWithVideoRotation)?.setTargetRotation(currentRotation)
+            } catch (t: Throwable) {
+                Log.w(TAG, "Failed to set target rotation on streamer: ${t.message}")
+            }
             service?.lockStreamRotation(currentRotation)
             Log.i(TAG, "Pre-locked stream rotation to $currentRotation before starting")
             

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -183,6 +183,13 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
     private val _encoderStatsLiveData = MutableLiveData<String?>(null)
     val encoderStatsLiveData: LiveData<String?> get() = _encoderStatsLiveData
 
+    val streamOrientationFlow: StateFlow<com.dimadesu.lifestreamer.models.StreamOrientation> =
+        storageRepository.streamOrientationFlow.stateIn(
+            viewModelScope,
+            SharingStarted.Eagerly,
+            com.dimadesu.lifestreamer.models.StreamOrientation.AUTO
+        )
+
     // Track whether the UI is in foreground (to avoid camera operations when paused)
     @Volatile
     private var isUiInForeground = true

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -1731,7 +1731,7 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
             
             // Lock stream rotation BEFORE starting to ensure it matches the user's
             // orientation preference.  If a fixed orientation is configured, honour it
-            // instead of blindly reading the display (which in split-screen is always portrait).
+            // instead of blindly reading the display.
             val fixedRotation = streamOrientationFlow.value.toSurfaceRotation()
             val currentRotation = if (fixedRotation != null) {
                 Log.i(TAG, "Using fixed stream orientation setting: ${streamOrientationFlow.value}")

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -3080,14 +3080,28 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
             Log.i(TAG, "No MediaProjection available, using mic")
         }
         
-        // Apply saved rotation BEFORE restarting stream to maintain original orientation
-        service?.getSavedStreamingOrientation()?.let { savedRotation ->
-            Log.i(TAG, "Applying saved rotation $savedRotation before RTMP restart")
-            try {
-                currentStreamer.setTargetRotation(savedRotation)
-            } catch (e: Exception) {
-                Log.w(TAG, "Failed to apply saved rotation: ${e.message}")
+        // Apply rotation BEFORE restarting stream to maintain consistent orientation
+        val fixedRotation = streamOrientationFlow.value.toSurfaceRotation()
+        val rotationToApply = if (fixedRotation != null) {
+            Log.i(TAG, "Applying fixed orientation setting $fixedRotation before RTMP restart")
+            fixedRotation
+        } else {
+            val savedRotation = service?.getSavedStreamingOrientation()
+            if (savedRotation != null) {
+                Log.i(TAG, "Applying saved rotation $savedRotation before RTMP restart")
+                savedRotation
+            } else {
+                val windowManager = application.getSystemService(Context.WINDOW_SERVICE) as android.view.WindowManager
+                @Suppress("DEPRECATION")
+                windowManager.defaultDisplay.rotation
             }
+        }
+        
+        try {
+            currentStreamer.setTargetRotation(rotationToApply)
+            service?.lockStreamRotation(rotationToApply)
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to apply rotation before RTMP restart: ${e.message}")
         }
         
         // Restart the stream

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -66,4 +66,20 @@
         <!-- <item>9</item> -->
     </string-array>
 
+    <string-array name="stream_orientation_entries">
+        <item>@string/stream_orientation_entry_auto</item>
+        <item>@string/stream_orientation_entry_portrait</item>
+        <item>@string/stream_orientation_entry_landscape</item>
+        <item>@string/stream_orientation_entry_portrait_reversed</item>
+        <item>@string/stream_orientation_entry_landscape_reversed</item>
+    </string-array>
+
+    <string-array name="stream_orientation_values">
+        <item>@string/stream_orientation_value_auto</item>
+        <item>@string/stream_orientation_value_portrait</item>
+        <item>@string/stream_orientation_value_landscape</item>
+        <item>@string/stream_orientation_value_portrait_reversed</item>
+        <item>@string/stream_orientation_value_landscape_reversed</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -361,4 +361,19 @@
     <string name="video_level_high_level62">HighLevel62</string>
     <string name="av_level_unknown">Unknown level</string>
 
+    <!-- Stream orientation setting -->
+    <string name="stream_orientation_key">stream_orientation</string>
+    <string name="stream_orientation_title">Stream orientation</string>
+    <string name="stream_orientation_summary">%s</string>
+    <string name="stream_orientation_value_auto">auto</string>
+    <string name="stream_orientation_value_portrait">portrait</string>
+    <string name="stream_orientation_value_landscape">landscape</string>
+    <string name="stream_orientation_value_portrait_reversed">portrait_reversed</string>
+    <string name="stream_orientation_value_landscape_reversed">landscape_reversed</string>
+    <string name="stream_orientation_entry_auto">Auto (follow device rotation)</string>
+    <string name="stream_orientation_entry_portrait">Portrait</string>
+    <string name="stream_orientation_entry_landscape">Landscape</string>
+    <string name="stream_orientation_entry_portrait_reversed">Portrait (reversed)</string>
+    <string name="stream_orientation_entry_landscape_reversed">Landscape (reversed)</string>
+
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -40,18 +40,18 @@
 
     <PreferenceCategory app:title="@string/video">
 
-        <ListPreference
-            app:key="@string/stream_orientation_key"
-            app:title="@string/stream_orientation_title"
-            app:summary="@string/stream_orientation_summary"
-            app:defaultValue="@string/stream_orientation_value_auto"
-            app:entryValues="@array/stream_orientation_values"
-            app:entries="@array/stream_orientation_entries"
-            app:useSimpleSummaryProvider="true" />
-
         <PreferenceCategory
             app:key="@string/video_settings_key"
             app:title="@string/settings">
+
+            <ListPreference
+                app:key="@string/stream_orientation_key"
+                app:title="@string/stream_orientation_title"
+                app:summary="@string/stream_orientation_summary"
+                app:defaultValue="@string/stream_orientation_value_auto"
+                app:entryValues="@array/stream_orientation_values"
+                app:entries="@array/stream_orientation_entries"
+                app:useSimpleSummaryProvider="true" />
 
             <ListPreference
                 app:defaultValue="@string/default_video_encoder"

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -40,6 +40,15 @@
 
     <PreferenceCategory app:title="@string/video">
 
+        <ListPreference
+            app:key="@string/stream_orientation_key"
+            app:title="@string/stream_orientation_title"
+            app:summary="@string/stream_orientation_summary"
+            app:defaultValue="@string/stream_orientation_value_auto"
+            app:entryValues="@array/stream_orientation_values"
+            app:entries="@array/stream_orientation_entries"
+            app:useSimpleSummaryProvider="true" />
+
         <PreferenceCategory
             app:key="@string/video_settings_key"
             app:title="@string/settings">


### PR DESCRIPTION
Five options: Auto (follows device rotation, existing behavior), Portrait, Landscape, Portrait Reversed, Landscape Reversed. Fixed orientations lock the Activity and stream encoder from app launch, not just during streaming.