### PR TITLE
Add R8 keep rules for reflective/serialized code paths

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,42 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# ---------------------------------------------------------------------------
+# LifeStreamer keep rules
+# minifyEnabled is true for the release build but the code below is reached
+# only via reflection / JSON, which R8's defaults do not protect. These bugs
+# surface only in release (debug is not minified), so keep the rules explicit.
+# ---------------------------------------------------------------------------
+
+# --- StreamPack endpoints loaded reflectively by Class.forName + getConstructor ---
+# See Endpoints.kt / CompositeEndpoints.kt in streampack-core. These live in the
+# separate extension modules and are referenced only by string literal, so R8
+# sees no static usage — keep the classes and their constructors unrenamed.
+# (RTMP / SRT / FLV outputs — the app's core streaming paths)
+-keep class io.github.thibaultbee.streampack.ext.rtmp.elements.endpoints.RtmpEndpoint { <init>(...); }
+-keep class io.github.thibaultbee.streampack.ext.flv.elements.endpoints.FlvFileEndpoint { <init>(...); }
+-keep class io.github.thibaultbee.streampack.ext.flv.elements.endpoints.FlvContentEndpoint { <init>(...); }
+-keep class io.github.thibaultbee.streampack.ext.srt.elements.endpoints.composites.sinks.SrtSink { <init>(...); }
+
+# --- Gson: reflection-based, ships no rules of its own ---
+-keepattributes Signature, *Annotation*, EnclosingMethod, InnerClasses
+-keep class com.google.gson.** { *; }
+-dontwarn com.google.gson.**
+# Third-party AAR class deserialized by Gson via field reflection (UVC saved size)
+-keep class com.serenegiant.usb.Size { *; }
+
+# --- kotlinx.serialization (belt-and-braces over the library's bundled rules) ---
+# Moblink wire-protocol models in bond-bunny/srtla-lib.
+-keepattributes RuntimeVisibleAnnotations, AnnotationDefault
+-keepclassmembers class **$$serializer { *; }
+-keep,includedescriptorclasses class com.dimadesu.bondbunny.moblink.**$$serializer { *; }
+-keepclassmembers class com.dimadesu.bondbunny.moblink.** {
+    *** Companion;
+    kotlinx.serialization.KSerializer serializer(...);
+}
+-keep class com.dimadesu.bondbunny.moblink.** { *; }
+
+# --- Readable release stack traces ---
+-keepattributes SourceFile,LineNumberTable
+-renamesourcefileattribute SourceFile


### PR DESCRIPTION
The release build enables minification but proguard-rules.pro was an empty
template. Testing showed the app's reflective/serialized paths already
survive R8 today thanks to its built-in heuristics and the default
optimize config — so this is a defensive hardening change, not a bug fix.
The rules make those contracts explicit and independent of R8 guessing
right across future toolchain upgrades.

Keep rules added:

- StreamPack RTMP/SRT/FLV endpoints: Endpoints.kt / CompositeEndpoints.kt
  instantiate these via Class.forName(...) + getConstructor(...), referenced
  only by string literal. R8's forName heuristic currently keeps the classes
  and rewrites the strings (verified: constructors present in seeds.txt even
  without rules), so streaming works today. Pinning them removes the reliance
  on that heuristic and keeps the classes unrenamed for readable stack traces.

- Gson: keeps the Gson runtime attributes and com.serenegiant.usb.Size, which
  is (de)serialized for saved UVC preview sizes. Note: Size is Parcelable, so
  the default config already preserves its fields (verified in the release
  DEX: type/width/height/fps/fpsList are intact without these rules) — the
  rule is belt-and-braces, not required.

- kotlinx.serialization: keeps the generated $$serializer classes and the
  Moblink wire-protocol models. kotlinx-serialization ships its own R8 rules
  that already cover this; these are additional insurance for the app's models.

Keep rules are additive only — they cannot break working code, worst case a
marginally larger APK. Also enables SourceFile/LineNumberTable for readable
release stack traces. Verified: assembleRelease succeeds with the rules and
the four reflectively-called constructors are retained with exact signatures.