### PR TITLE
Hide SRTLA stats view when user changes endpoint from SRTLA to something else

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -3971,11 +3971,35 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
 
     val videoConfigLiveData: LiveData<VideoConfig?> = storageRepository.videoConfigFlow.asLiveData()
 
-    private val _isSrtlaStatsVisible = MutableLiveData(false)
-    val isSrtlaStatsVisible: LiveData<Boolean> = _isSrtlaStatsVisible
+    /**
+     * Raw "user tapped SRTLA STATS" toggle. Not directly exposed: actual visibility is
+     * derived from this AND the current endpoint being SRTLA (see [isSrtlaStatsVisible]),
+     * so the panel auto-hides when the endpoint changes away from SRTLA, and auto-reappears
+     * if the endpoint is switched back to SRTLA while the toggle is still on.
+     */
+    private val _isSrtlaStatsToggledOn = MutableLiveData(false)
+
+    /**
+     * Whether the SRTLA stats panel should be shown. Derived from [isSrtlaEndpoint] combined
+     * with the user's toggle state, so it automatically hides (and re-shows) as the endpoint
+     * changes, without requiring the SRTLA STATS button to be visible to dismiss it.
+     */
+    val isSrtlaStatsVisible: LiveData<Boolean> = MediatorLiveData<Boolean>().apply {
+        value = false
+        var endpointIsSrtla = false
+        var toggledOn = false
+        addSource(isSrtlaEndpoint) {
+            endpointIsSrtla = it
+            value = endpointIsSrtla && toggledOn
+        }
+        addSource(_isSrtlaStatsToggledOn) {
+            toggledOn = it
+            value = endpointIsSrtla && toggledOn
+        }
+    }
 
     fun setSrtlaStatsVisible(visible: Boolean) {
-        _isSrtlaStatsVisible.value = visible
+        _isSrtlaStatsToggledOn.value = visible
     }
 
     /**


### PR DESCRIPTION
Previously, SrtlaStatsView visibility was tracked by an independent flag (_isSrtlaStatsVisible) with no relation to the current endpoint. The SRTLA STATS button that toggles it is only visible while isSrtlaEndpoint is true (goneUnless), so if the panel was open and the user switched the endpoint to something else in settings, the panel stayed stuck open with no way to dismiss it.

Fix: isSrtlaStatsVisible is now derived by combining isSrtlaEndpoint with the user's toggle state via MediatorLiveData (visible = endpointIsSrtla && toggledOn), mirroring the existing showCameraControls pattern. The raw toggle state is preserved separately (_isSrtlaStatsToggledOn) so:
- Leaving the SRTLA endpoint immediately hides the panel, stops stats polling, and resets the button tint (all already handled by the existing observer in PreviewFragment).
- Switching back to SRTLA re-shows the panel automatically if it was toggled on before leaving, without requiring another tap.