### PR TITLE
Add audio bitrate options 96, 160, 256 and 320 kbps, remove 24 kbps

### DIFF
--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -35,10 +35,13 @@
     </string-array>
 
     <string-array name="AudioBitrateEntryValues">
-        <item>24000</item>
         <item>64000</item>
+        <item>96000</item>
         <item>128000</item>
+        <item>160000</item>
         <item>192000</item>
+        <item>256000</item>
+        <item>320000</item>
     </string-array>
 
     <!-- Audio Source Types (MediaRecorder.AudioSource constants) -->


### PR DESCRIPTION
Add 96, 160, 256, and 320 kbps options to AudioBitrateEntryValues and remove the 24 kbps option, which was too low quality for streaming.