### PR TITLE
Fix app crash on RTMP SRC button tap for 16 KB devices. Switch ExoPlayer RTMP library to version with NDK r28c for proper 16KB page alignment

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -109,8 +109,8 @@ dependencies {
     implementation("androidx.media3:media3-datasource-rtmp:1.8.0") {
         exclude(group = "io.antmedia", module = "rtmp-client")
     }
-    // Use JitPack version with 16KB page alignment fix (PR #110 merged Sep 2025)
-    implementation("com.github.mcxinyu:LibRtmp-Client-for-Android:v3.2.0.m2")
+    // Use fork with NDK r28c for proper 16KB page alignment (fixes Google Play warning)
+    implementation("com.github.dimadesu:LibRtmp-Client-for-Android:v3.2.0-16kb-ndk-r28c")
 
     testImplementation(libs.junit)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -109,8 +109,8 @@ dependencies {
     implementation("androidx.media3:media3-datasource-rtmp:1.8.0") {
         exclude(group = "io.antmedia", module = "rtmp-client")
     }
-    // Use JitPack version with 16KB page alignment fix (PR #110 merged Sep 2025)
-    implementation("com.github.mcxinyu:LibRtmp-Client-for-Android:v3.2.0.m2")
+    // Use JitPack build from fork with NDK r28c for proper 16KB page alignment
+    implementation("com.github.dimadesu:LibRtmp-Client-for-Android:v3.2.0-16kb-ndk-r28c-v2")
 
     testImplementation(libs.junit)
 


### PR DESCRIPTION
Google Play warning screenshot:

<img width="749" height="419" alt="Screenshot 2026-07-31 at 9 18 40 pm" src="https://github.com/user-attachments/assets/8f20d356-a881-450e-8388-28049740f47b" />

Google Play warning text:

```
Your app could crash on 16 KB devices

Your app is compiled for 16 KB devices, but some of its libraries were compiled using an older Android NDK version that can still cause crashes. The following libraries in your app may be affected:

base/lib/arm64-v8a/librtmp-jni.so

To fix this issue, choose one of the following:
- Upgrade to NDK r28 or higher to resolve this automatically.
- Recompile your libraries and manually enable linker flags if you can't upgrade. If your code relies on the PAGE_SIZE macro, you must replace all instances.
```

'Learn more' goes here https://developer.android.com/guide/practices/page-sizes#compile-r27-lower

---

Performed steps:
- I forked a fork of a fork of RTMP lib that seems to have all the fixes I need.
- Then I created a tag https://github.com/dimadesu/LibRtmp-Client-for-Android/releases/tag/v3.2.0-16kb-ndk-r28c-v2
- Triggered the JitPack build by visiting: https://jitpack.io/#dimadesu/LibRtmp-Client-for-Android/v3.2.0-16kb-ndk-r28c-v2
- Updated LS (this PR) to use it.
- Build LS.
- Tested on 2x 16 KB emulators
- Upload to Google Play internal test track to verify the 16KB warning is gone.