### PR TITLE
Mark hardware features as not required in manifest to allow installing apps from Play Store on emulators

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,8 +33,10 @@
     <uses-permission android:name="android.permission.CAPTURE_VIDEO_OUTPUT" />
     <uses-permission android:name="android.permission.PROJECT_MEDIA" />
 
-    <uses-feature android:name="android.hardware.camera" />
-    <uses-feature android:name="android.hardware.microphone" />
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
+    <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
+    <uses-feature android:name="android.hardware.microphone" android:required="false" />
+    <uses-feature android:name="android.hardware.bluetooth" android:required="false" />
 
     <queries>
         <package android:name="com.dimadesu.mediasrvr" />


### PR DESCRIPTION
Set android:required="false" on uses-feature declarations for android.hardware.camera, android.hardware.camera.autofocus, android.hardware.microphone, and android.hardware.bluetooth.

Without this, these features default to required="true" (either explicitly or implicitly from CAMERA, RECORD_AUDIO, and BLUETOOTH permissions), which causes Google Play to filter out the app on devices that don't report the corresponding hardware (e.g. emulators like Pixel 10 Pro virtual device), showing "This app won't work on your device".

The app still requests the relevant runtime permissions, so functionality on real devices is completely unaffected. This matches the existing pattern used for android.hardware.usb.host.