### PR TITLE
Mark USB host hardware as not required in the final merged manifest to allow installing app on emulators from Play Store

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,8 +19,8 @@ android {
         targetSdk = 36
         compileSdk = 36
 
-        versionCode = 34
-        versionName = "1.40.1"
+        versionCode = 35
+        versionName = "1.40.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
     <!-- Explicitly remove MANAGE_EXTERNAL_STORAGE added by dependencies -->
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" tools:node="remove" />
 
-    <uses-feature android:name="android.hardware.usb.host" android:required="false" />
+    <uses-feature android:name="android.hardware.usb.host" android:required="false" tools:replace="android:required" />
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />


### PR DESCRIPTION
A UVC camera dependency declares android.hardware.usb.host with android:required="true". During manifest merging the stricter value wins, so the final APK was marked as requiring USB host hardware. This caused the Play Store (and direct installs) to filter the app as incompatible with emulators and any device lacking a USB host controller.

Adding tools:replace="android:required" forces the merger to use our android:required="false", making USB host support optional and restoring compatibility with emulators and non-USB-host devices.

---

`tools:replace="android:required"` is an **Android Manifest Merger directive**.

- One of your **library dependencies** declares `<uses-feature android:name="android.hardware.usb.host" android:required="true" />` in *its* manifest.
- During the build, Android's **manifest merger** combines all manifests (yours + all dependencies) into one final manifest.
- Without `tools:replace`, the merger sees a **conflict** — the library says `required="true"` but you say `required="false"` — and it would either fail or default to the library's `true`.
- **`tools:replace="android:required"`** tells the merger: *"For this element, override the `android:required` attribute with the value I've specified here, instead of using the one from the library."*

**Net effect:** The final merged manifest has `android.hardware.usb.host` with `required="false"`, meaning:
- Your app **can** use USB host hardware when available.
- But it's **not required**, so devices without USB host support (like emulators) are still considered compatible — which is exactly the fix for the emulator installation issue you were debugging.