### PR TITLE
Add "Quit" button to main screen dropdown menu. Improve how quitting app works. Improve clearing view model

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/MainActivity.kt
@@ -66,24 +66,28 @@ class MainActivity : AppCompatActivity() {
                     .commitNow()
             }
         } else if (action == "com.dimadesu.lifestreamer.action.EXIT_APP") {
-            // Exit requested via notification: properly stop service and finish activity
-            try {
-                // Stop service gracefully
-                val stopIntent = Intent(this, com.dimadesu.lifestreamer.services.CameraStreamerService::class.java)
-                stopService(stopIntent)
-            } catch (_: Exception) {
-                // Service might not be running, that's okay
-            }
-            
-            // Move task to back instead of abruptly finishing
-            // This gives the service time to cleanup and avoids crash detection
-            moveTaskToBack(true)
-            
-            // Schedule actual finish after a short delay to ensure service cleanup
-            android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
-                finishAndRemoveTask()
-            }, 300)
+            exitApp()
         }
+    }
+
+    private fun exitApp() {
+        // Exit requested: properly stop service and finish activity
+        try {
+            // Stop service gracefully
+            val stopIntent = Intent(this, com.dimadesu.lifestreamer.services.CameraStreamerService::class.java)
+            stopService(stopIntent)
+        } catch (_: Exception) {
+            // Service might not be running, that's okay
+        }
+
+        // Move task to back instead of abruptly finishing
+        // This gives the service time to cleanup and avoids crash detection
+        moveTaskToBack(true)
+
+        // Schedule actual finish after a short delay to ensure service cleanup
+        android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
+            finishAndRemoveTask()
+        }, 300)
     }
 
     private fun bindProperties() {
@@ -121,6 +125,10 @@ class MainActivity : AppCompatActivity() {
                 }
                 R.id.action_known_issues -> {
                     goToKnownIssuesActivity()
+                    true
+                }
+                R.id.action_quit -> {
+                    exitApp()
                     true
                 }
                 else -> {

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/MainActivity.kt
@@ -24,6 +24,8 @@ import android.widget.PopupMenu
 import androidx.appcompat.app.AppCompatActivity
 import com.dimadesu.lifestreamer.R
 import com.dimadesu.lifestreamer.databinding.MainActivityBinding
+import com.dimadesu.lifestreamer.rtmp.audio.MediaProjectionService
+import com.dimadesu.lifestreamer.services.CameraStreamerService
 import com.dimadesu.lifestreamer.ui.settings.SettingsActivity
 import com.dimadesu.lifestreamer.ui.help.FaqHelpActivity
 import com.dimadesu.lifestreamer.ui.help.KnownIssuesActivity
@@ -36,6 +38,15 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // Notification Quit starts a new activity when none is running.
+        // Handle it here — onNewIntent is not called for a fresh launch —
+        // and skip UI/service bind so we don't race teardown.
+        if (intent?.action == CameraStreamerService.ACTION_EXIT_APP) {
+            exitApp()
+            return
+        }
+
         binding = MainActivityBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
@@ -53,10 +64,13 @@ class MainActivity : AppCompatActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
+        setIntent(intent)
         // Handle notification tap action to avoid re-creating activity and
         // triggering unnecessary view detach/attach which can race with camera.
         val action = intent.action
-        if (action == "com.dimadesu.lifestreamer.ACTION_OPEN_FROM_NOTIFICATION") {
+        if (action == CameraStreamerService.ACTION_EXIT_APP) {
+            exitApp()
+        } else if (action == CameraStreamerService.ACTION_OPEN_FROM_NOTIFICATION) {
             // If the PreviewFragment is already present, do nothing. If not,
             // ensure it's added without recreating the fragment stack.
             val current = supportFragmentManager.findFragmentById(R.id.container)
@@ -65,29 +79,28 @@ class MainActivity : AppCompatActivity() {
                     .replace(R.id.container, PreviewFragment())
                     .commitNow()
             }
-        } else if (action == "com.dimadesu.lifestreamer.action.EXIT_APP") {
-            exitApp()
         }
     }
 
     private fun exitApp() {
-        // Exit requested: properly stop service and finish activity
+        // Unbind first: a started+bound service ignores stopService() until
+        // every client unbinds. PreviewViewModel otherwise unbinds only in
+        // onCleared(), which runs after the activity is already finishing.
+        (supportFragmentManager.findFragmentById(R.id.container) as? PreviewFragment)
+            ?.prepareForExit()
+
         try {
-            // Stop service gracefully
-            val stopIntent = Intent(this, com.dimadesu.lifestreamer.services.CameraStreamerService::class.java)
-            stopService(stopIntent)
+            stopService(Intent(this, CameraStreamerService::class.java))
         } catch (_: Exception) {
             // Service might not be running, that's okay
         }
+        try {
+            stopService(Intent(this, MediaProjectionService::class.java))
+        } catch (_: Exception) {
+            // Optional companion service; ignore if absent
+        }
 
-        // Move task to back instead of abruptly finishing
-        // This gives the service time to cleanup and avoids crash detection
-        moveTaskToBack(true)
-
-        // Schedule actual finish after a short delay to ensure service cleanup
-        android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
-            finishAndRemoveTask()
-        }, 300)
+        finishAndRemoveTask()
     }
 
     private fun bindProperties() {

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewFragment.kt
@@ -668,6 +668,14 @@ class PreviewFragment : Fragment(R.layout.main_fragment) {
         previewViewModel.stopStream()
     }
 
+    /**
+     * Unbind the streamer service before [android.content.Context.stopService] so
+     * a started+bound CameraStreamerService can actually be destroyed on Quit.
+     */
+    fun prepareForExit() {
+        previewViewModel.prepareForExit()
+    }
+
     override fun onDestroyView() {
         super.onDestroyView()
     }

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -4384,8 +4384,19 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
         //     Log.e(TAG, "Streamer release failed", t)
         // }
 
+        // Capture streaming state before unbinding (unbind nulls serviceStreamer)
+        val serviceIsStreaming = serviceStreamer?.isStreamingFlow?.value == true
+
         unbindStreamerService()
-        releaseMediaProjection()
+
+        // Only release MediaProjection if the service is NOT actively streaming.
+        // The service may still be running in the background (started service) and
+        // needs the projection for audio capture (e.g. RTMP source).
+        if (!serviceIsStreaming) {
+            releaseMediaProjection()
+        } else {
+            Log.i(TAG, "Skipping MediaProjection release — service is still streaming")
+        }
         Log.i(TAG, "PreviewViewModel cleared")
     }
 

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -4384,26 +4384,47 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
         //     Log.e(TAG, "Streamer release failed", t)
         // }
 
-        // Always unbind from the service - since we started it independently,
-        // unbinding won't destroy it and it should continue streaming in background
+        unbindStreamerService()
+        releaseMediaProjection()
+        Log.i(TAG, "PreviewViewModel cleared")
+    }
+
+    /**
+     * Drop the service bind so a following [Context.stopService] can destroy
+     * CameraStreamerService. Safe to call more than once.
+     */
+    fun prepareForExit() {
+        Log.i(TAG, "prepareForExit: unbinding so stopService can take effect")
+        try {
+            streamerService?.markUserStoppedManually()
+        } catch (_: Throwable) {}
+        unbindStreamerService()
+        releaseMediaProjection()
+    }
+
+    private fun unbindStreamerService() {
         serviceConnection?.let { connection ->
-            application.unbindService(connection)
-            Log.i(TAG, "Unbound from CameraStreamerService - service continues running independently")
+            try {
+                application.unbindService(connection)
+                Log.i(TAG, "Unbound from CameraStreamerService")
+            } catch (e: Exception) {
+                Log.w(TAG, "unbindService failed: ${e.message}")
+            }
         }
-
-        // Don't clear service state - the service should continue running independently
-        // Only clear the ViewModel's local references
         streamerService = null
+        serviceBinder = null
+        serviceStreamer = null
         serviceConnection = null
-        // DO NOT set _serviceReady.value = false here - the service is still running!
+        streamerFlow.value = null
+        _serviceReady.value = false
+    }
 
-        // Clean up MediaProjection resources
-        streamingMediaProjection?.stop()
+    private fun releaseMediaProjection() {
+        try { streamingMediaProjection?.stop() } catch (_: Throwable) {}
         streamingMediaProjection = null
-        startupMediaProjection?.stop()
+        try { startupMediaProjection?.stop() } catch (_: Throwable) {}
         startupMediaProjection = null
         mediaProjectionHelper.release()
-        Log.i(TAG, "PreviewViewModel cleared but service continues running for background streaming")
     }
 
     /**

--- a/app/src/main/res/menu/actions.xml
+++ b/app/src/main/res/menu/actions.xml
@@ -31,4 +31,9 @@
         android:orderInCategory="105"
         android:title="@string/action_faq"
         app:showAsAction="never" />
+    <item
+        android:id="@+id/action_quit"
+        android:orderInCategory="106"
+        android:title="@string/action_quit"
+        app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="action_uvc_help">How to use USB source</string>
     <string name="action_faq">FAQ</string>
     <string name="action_known_issues">Known issues and workarounds</string>
+    <string name="action_quit">Quit</string>
     <string name="menu_actions">Menu actions</string>
 
     <!-- Camera Streaming Service -->


### PR DESCRIPTION
- Add 'Quit' item at the end of the actions popup menu
- Extract exit logic from onNewIntent into reusable exitApp() method
- Reuse same behavior as notification Quit: stop service, finish activity