### PR TITLE
Preserve Media Projection token when view model is cleared

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/rtmp/audio/MediaProjectionHelper.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/rtmp/audio/MediaProjectionHelper.kt
@@ -1,6 +1,7 @@
 package com.dimadesu.lifestreamer.rtmp.audio
 
 import android.app.Activity
+import android.app.ActivityManager
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
@@ -207,6 +208,59 @@ class MediaProjectionHelper(private val context: Context) {
             Log.w(TAG, "Service not bound, cannot get MediaProjection")
             null
         }
+    }
+
+    /**
+     * Try to reconnect to an already-running MediaProjectionService.
+     * This is used when the ViewModel is recreated (e.g. after the user swipes away
+     * the UI from recents) but the foreground service survived.
+     *
+     * @param callback Called with the recovered MediaProjection, or null if the service
+     *                 is not running or binding fails.
+     */
+    fun tryReconnect(callback: (MediaProjection?) -> Unit) {
+        if (isBound) {
+            Log.i(TAG, "tryReconnect: already bound, returning existing projection")
+            callback(getMediaProjection())
+            return
+        }
+
+        if (!isServiceRunning()) {
+            Log.i(TAG, "tryReconnect: MediaProjectionService is not running")
+            callback(null)
+            return
+        }
+
+        Log.i(TAG, "tryReconnect: service is running, attempting to bind...")
+        onProjectionReady = callback
+        val serviceIntent = Intent(context, MediaProjectionService::class.java)
+        try {
+            val bindResult = context.bindService(serviceIntent, serviceConnection, Context.BIND_AUTO_CREATE)
+            Log.i(TAG, "tryReconnect: bindService() returned: $bindResult")
+            if (!bindResult) {
+                Log.e(TAG, "tryReconnect: bindService() returned false")
+                onProjectionReady = null
+                callback(null)
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "tryReconnect: bindService() failed: ${e.message}", e)
+            onProjectionReady = null
+            callback(null)
+        }
+    }
+
+    /**
+     * Check if MediaProjectionService is currently running as a foreground service.
+     */
+    @Suppress("DEPRECATION")
+    private fun isServiceRunning(): Boolean {
+        val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        for (service in activityManager.getRunningServices(Int.MAX_VALUE)) {
+            if (MediaProjectionService::class.java.name == service.service.className) {
+                return true
+            }
+        }
+        return false
     }
 
     /**

--- a/app/src/main/java/com/dimadesu/lifestreamer/rtmp/audio/MediaProjectionHelper.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/rtmp/audio/MediaProjectionHelper.kt
@@ -1,7 +1,6 @@
 package com.dimadesu.lifestreamer.rtmp.audio
 
 import android.app.Activity
-import android.app.ActivityManager
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
@@ -250,17 +249,10 @@ class MediaProjectionHelper(private val context: Context) {
     }
 
     /**
-     * Check if MediaProjectionService is currently running as a foreground service.
+     * Check if MediaProjectionService is currently running.
      */
-    @Suppress("DEPRECATION")
     private fun isServiceRunning(): Boolean {
-        val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
-        for (service in activityManager.getRunningServices(Int.MAX_VALUE)) {
-            if (MediaProjectionService::class.java.name == service.service.className) {
-                return true
-            }
-        }
-        return false
+        return MediaProjectionService.isRunning
     }
 
     /**

--- a/app/src/main/java/com/dimadesu/lifestreamer/rtmp/audio/MediaProjectionHelper.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/rtmp/audio/MediaProjectionHelper.kt
@@ -275,6 +275,26 @@ class MediaProjectionHelper(private val context: Context) {
     }
 
     /**
+     * Unbind from the MediaProjection service without stopping it.
+     * Use this in ViewModel.onCleared() so the foreground service survives
+     * for a new ViewModel to recover via tryReconnect().
+     */
+    fun unbind() {
+        Log.i(TAG, "unbind() called - isBound: $isBound")
+        if (isBound) {
+            try {
+                context.unbindService(serviceConnection)
+                Log.i(TAG, "Successfully unbound from service (service kept alive)")
+            } catch (e: Exception) {
+                Log.w(TAG, "Error unbinding from service: ${e.message}", e)
+            }
+            isBound = false
+            mediaProjectionService = null
+        }
+        onProjectionReady = null
+    }
+
+    /**
      * Release the MediaProjection resources.
      * Call this when you're done with audio capture.
      */

--- a/app/src/main/java/com/dimadesu/lifestreamer/rtmp/audio/MediaProjectionService.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/rtmp/audio/MediaProjectionService.kt
@@ -30,6 +30,11 @@ class MediaProjectionService : Service() {
         private const val CHANNEL_ID = "media_projection_channel"
         private const val EXTRA_RESULT_CODE = "result_code"
         private const val EXTRA_RESULT_DATA = "result_data"
+
+        /** True while the service is alive (between onCreate and onDestroy). */
+        @Volatile
+        var isRunning: Boolean = false
+            private set
     }
 
     inner class LocalBinder : Binder() {
@@ -38,6 +43,7 @@ class MediaProjectionService : Service() {
 
     override fun onCreate() {
         super.onCreate()
+        isRunning = true
         Log.i(TAG, "Service created")
         createNotificationChannel()
     }
@@ -73,6 +79,7 @@ class MediaProjectionService : Service() {
 
     override fun onDestroy() {
         Log.i(TAG, "Service destroyed")
+        isRunning = false
         mediaProjection?.stop()
         mediaProjection = null
         super.onDestroy()

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -660,6 +660,16 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
         // Bind to streaming service for background streaming capability
         bindToStreamerService()
 
+        // Try to recover a MediaProjection token from a still-running
+        // MediaProjectionService (e.g. after the user swiped the UI from recents
+        // but the foreground service survived).
+        mediaProjectionHelper.tryReconnect { projection ->
+            if (projection != null) {
+                Log.i(TAG, "Recovered MediaProjection from surviving service")
+                startupMediaProjection = projection
+            }
+        }
+
         // Initialize LiveData flows
         viewModelScope.launch {
             serviceReadyFlow.collect { isReady ->
@@ -4384,20 +4394,13 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
         //     Log.e(TAG, "Streamer release failed", t)
         // }
 
-        // Capture streaming state before unbinding (unbind nulls serviceStreamer)
-        val serviceIsStreaming = serviceStreamer?.isStreamingFlow?.value == true
-
         unbindStreamerService()
 
-        // Only release MediaProjection if the service is NOT actively streaming.
-        // The service may still be running in the background (started service) and
-        // needs the projection for audio capture (e.g. RTMP source).
-        if (!serviceIsStreaming) {
-            releaseMediaProjection()
-        } else {
-            Log.i(TAG, "Skipping MediaProjection release — service is still streaming")
-        }
-        Log.i(TAG, "PreviewViewModel cleared")
+        // Don't release MediaProjection here — the MediaProjectionService may still
+        // be running as a foreground service, and a new ViewModel (after UI recreation)
+        // can recover the token via tryReconnect(). Release only happens in
+        // prepareForExit() when the user explicitly quits the app.
+        Log.i(TAG, "PreviewViewModel cleared (MediaProjection preserved for possible UI recreation)")
     }
 
     /**

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -4396,11 +4396,12 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
 
         unbindStreamerService()
 
-        // Don't release MediaProjection here — the MediaProjectionService may still
-        // be running as a foreground service, and a new ViewModel (after UI recreation)
-        // can recover the token via tryReconnect(). Release only happens in
-        // prepareForExit() when the user explicitly quits the app.
-        Log.i(TAG, "PreviewViewModel cleared (MediaProjection preserved for possible UI recreation)")
+        // Unbind from the MediaProjection service, but don't stop it — the
+        // MediaProjectionService may still be running as a foreground service, and
+        // a new ViewModel (after UI recreation) can recover the token via tryReconnect().
+        // Full release only happens in prepareForExit() when the user explicitly quits.
+        mediaProjectionHelper.unbind()
+        Log.i(TAG, "PreviewViewModel cleared (MediaProjection service preserved for possible UI recreation)")
     }
 
     /**


### PR DESCRIPTION
Previously, onCleared() released the MediaProjection when the service wasn't streaming. This caused the token to be lost when the user swiped away the UI from recents — even though the MediaProjectionService (foreground service) survived the process trim.

When the user re-opened the app, a new ViewModel was created but had no way to recover the still-valid token, forcing a new permission dialog.

Changes:
- Remove releaseMediaProjection() from onCleared(). The token and its backing service are now only torn down in prepareForExit() (explicit app quit).
- Add MediaProjectionHelper.tryReconnect() which binds to an already-running MediaProjectionService and recovers the projection. Uses ActivityManager.getRunningServices() to check liveness first.
- Call tryReconnect() in PreviewViewModel init so a recreated ViewModel automatically recovers startupMediaProjection from the surviving service.