### PR TITLE
Fix: Reset encoder to safe 1 Mbps bitrate before re-attaching adaptive bitrate regulator mid-stream. Deduplicate code

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
@@ -355,6 +355,13 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
                                 
                                 // Re-add with new config if enabled
                                 if (config != null) {
+                                    // Reset encoder to the safe starting bitrate before attaching a
+                                    // fresh regulator instance, so its first tick ramps up from 1 Mbps
+                                    // instead of cliff-dropping down from whatever bitrate was active.
+                                    streamConfigurationHelper.applySafeInitialBitrate(
+                                        streamer as? IVideoSingleStreamer,
+                                        TAG
+                                    )
                                     val factory = if (descriptor.type.sinkType == MediaSinkType.SRT) {
                                         AdaptiveSrtBitrateRegulatorController.Factory(
                                             bitrateRegulatorConfig = config,

--- a/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/services/CameraStreamerService.kt
@@ -33,7 +33,6 @@ import androidx.core.app.ServiceCompat
 import com.dimadesu.lifestreamer.services.utils.NotificationUtils
 import com.dimadesu.lifestreamer.ui.main.MainActivity
 import com.dimadesu.lifestreamer.data.storage.DataStoreRepository
-import com.dimadesu.lifestreamer.bitrate.AdaptiveSrtBitrateRegulatorController
 import com.dimadesu.lifestreamer.utils.dataStore
 import com.dimadesu.lifestreamer.utils.StreamConfigurationHelper
 import com.dimadesu.lifestreamer.models.StreamStatus
@@ -349,31 +348,12 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
                             val descriptor = storageRepository.endpointDescriptorFlow.first()
                             if (descriptor.type.sinkType == MediaSinkType.SRT || descriptor.type.sinkType == MediaSinkType.RTMP) {
                                 Log.i(TAG, "Bitrate regulator settings changed during stream - updating controller")
-                                
-                                // Remove old controller
-                                (streamer as? IVideoSingleStreamer)?.bitrateRegulatorControllerFactory = null
-                                
-                                // Re-add with new config if enabled
+                                streamConfigurationHelper.attachBitrateRegulator(
+                                    streamer as? IVideoSingleStreamer,
+                                    descriptor.type.sinkType,
+                                    TAG
+                                )
                                 if (config != null) {
-                                    // Reset encoder to the safe starting bitrate before attaching a
-                                    // fresh regulator instance, so its first tick ramps up from 1 Mbps
-                                    // instead of cliff-dropping down from whatever bitrate was active.
-                                    streamConfigurationHelper.applySafeInitialBitrate(
-                                        streamer as? IVideoSingleStreamer,
-                                        TAG
-                                    )
-                                    val factory = if (descriptor.type.sinkType == MediaSinkType.SRT) {
-                                        AdaptiveSrtBitrateRegulatorController.Factory(
-                                            bitrateRegulatorConfig = config,
-                                            mode = mode
-                                        )
-                                    } else {
-                                        io.github.thibaultbee.streampack.core.regulator.controllers.intervalBitrateRegulatorControllerFactory(
-                                            bitrateRegulatorFactory = com.dimadesu.lifestreamer.bitrate.RtmpSendDurationBitrateRegulator.Factory(),
-                                            bitrateRegulatorConfig = config
-                                        )
-                                    }
-                                    (streamer as? IVideoSingleStreamer)?.bitrateRegulatorControllerFactory = factory
                                     Log.i(TAG, "Bitrate regulator updated: range=${config.videoBitrateRange.lower/1000}k-${config.videoBitrateRange.upper/1000}k, mode=$mode")
                                 } else {
                                     Log.i(TAG, "Bitrate regulator disabled")
@@ -1275,31 +1255,14 @@ class CameraStreamerService : StreamerService<ISingleStreamer>(
             }
 
             // If SRT or RTMP sink, possibly attach bitrate regulator controller based on stored config
-            if (descriptor.type.sinkType == MediaSinkType.SRT || descriptor.type.sinkType == MediaSinkType.RTMP) {
-                val bitrateRegulatorConfig = try {
-                    storageRepository.bitrateRegulatorConfigFlow.first()
-                } catch (e: Exception) {
-                    null
-                }
-                if (bitrateRegulatorConfig != null) {
-                    try {
-                        val mode = try { storageRepository.regulatorModeFlow.first() } catch (_: Exception) { com.dimadesu.lifestreamer.bitrate.RegulatorMode.MOBLIN_FAST }
-                        val factory = if (descriptor.type.sinkType == MediaSinkType.SRT) {
-                            AdaptiveSrtBitrateRegulatorController.Factory(
-                                bitrateRegulatorConfig = bitrateRegulatorConfig,
-                                mode = mode
-                            )
-                        } else {
-                            io.github.thibaultbee.streampack.core.regulator.controllers.intervalBitrateRegulatorControllerFactory(
-                                bitrateRegulatorFactory = com.dimadesu.lifestreamer.bitrate.RtmpSendDurationBitrateRegulator.Factory(),
-                                bitrateRegulatorConfig = bitrateRegulatorConfig
-                            )
-                        }
-                        (currentStreamer as? IVideoSingleStreamer)?.bitrateRegulatorControllerFactory = factory
-                    } catch (e: Exception) {
-                        Log.w(TAG, "Failed to attach bitrate regulator: ${e.message}")
-                    }
-                }
+            try {
+                streamConfigurationHelper.attachBitrateRegulator(
+                    currentStreamer as? IVideoSingleStreamer,
+                    descriptor.type.sinkType,
+                    TAG
+                )
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to attach bitrate regulator: ${e.message}")
             }
 
             Log.i(TAG, "startStreamFromConfiguredEndpoint: stream started successfully")

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -749,6 +749,13 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                 val selectedMode = storageRepository.regulatorModeFlow.first()
                 // Small delay to let the new encoder initialize
                 delay(200)
+                // Reset encoder to the safe starting bitrate before attaching a fresh regulator
+                // instance, so its first tick ramps up from 1 Mbps instead of cliff-dropping down
+                // from whatever bitrate was active before the source switch/reconnect.
+                streamConfigurationHelper.applySafeInitialBitrate(
+                    currentStreamer as? io.github.thibaultbee.streampack.core.streamers.single.IVideoSingleStreamer,
+                    TAG
+                )
                 currentStreamer.bitrateRegulatorControllerFactory = if (sinkType == MediaSinkType.SRT) {
                     AdaptiveSrtBitrateRegulatorController.Factory(
                         bitrateRegulatorConfig = bitrateRegulatorConfig,

--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -84,7 +84,6 @@ import io.github.thibaultbee.streampack.core.streamers.single.VideoConfig
 import io.github.thibaultbee.streampack.core.streamers.single.AudioConfig
 import com.dimadesu.lifestreamer.services.CameraStreamerService
 import io.github.thibaultbee.streampack.core.interfaces.IWithVideoRotation
-import com.dimadesu.lifestreamer.bitrate.AdaptiveSrtBitrateRegulatorController
 import com.dimadesu.lifestreamer.models.StreamStatus
 import com.dimadesu.lifestreamer.srtla.SrtlaManager
 import com.serenegiant.utils.UVCUtils.getApplication
@@ -744,29 +743,14 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
         if (sinkType != MediaSinkType.SRT && sinkType != MediaSinkType.RTMP) return
         
         try {
-            val bitrateRegulatorConfig = storageRepository.bitrateRegulatorConfigFlow.first()
-            if (bitrateRegulatorConfig != null) {
-                val selectedMode = storageRepository.regulatorModeFlow.first()
+            if (storageRepository.bitrateRegulatorConfigFlow.first() != null) {
                 // Small delay to let the new encoder initialize
                 delay(200)
-                // Reset encoder to the safe starting bitrate before attaching a fresh regulator
-                // instance, so its first tick ramps up from 1 Mbps instead of cliff-dropping down
-                // from whatever bitrate was active before the source switch/reconnect.
-                streamConfigurationHelper.applySafeInitialBitrate(
+                streamConfigurationHelper.attachBitrateRegulator(
                     currentStreamer as? io.github.thibaultbee.streampack.core.streamers.single.IVideoSingleStreamer,
+                    sinkType,
                     TAG
                 )
-                currentStreamer.bitrateRegulatorControllerFactory = if (sinkType == MediaSinkType.SRT) {
-                    AdaptiveSrtBitrateRegulatorController.Factory(
-                        bitrateRegulatorConfig = bitrateRegulatorConfig,
-                        mode = selectedMode
-                    )
-                } else {
-                    io.github.thibaultbee.streampack.core.regulator.controllers.intervalBitrateRegulatorControllerFactory(
-                        bitrateRegulatorFactory = com.dimadesu.lifestreamer.bitrate.RtmpSendDurationBitrateRegulator.Factory(),
-                        bitrateRegulatorConfig = bitrateRegulatorConfig
-                    )
-                }
                 Log.i(TAG, "Re-added bitrate regulator after video source switch")
             }
         } catch (e: Exception) {
@@ -897,23 +881,11 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
             Log.i(TAG, "startServiceStreaming: Stream started successfully")
             
             // Add bitrate regulator for SRT and RTMP streams
-            if (descriptor.type.sinkType == MediaSinkType.SRT || descriptor.type.sinkType == MediaSinkType.RTMP) {
-                val bitrateRegulatorConfig = storageRepository.bitrateRegulatorConfigFlow.first()
-                if (bitrateRegulatorConfig != null) {
-                    val selectedMode = storageRepository.regulatorModeFlow.first()
-                    currentStreamer.bitrateRegulatorControllerFactory = if (descriptor.type.sinkType == MediaSinkType.SRT) {
-                        AdaptiveSrtBitrateRegulatorController.Factory(
-                            bitrateRegulatorConfig = bitrateRegulatorConfig,
-                            mode = selectedMode
-                        )
-                    } else {
-                        io.github.thibaultbee.streampack.core.regulator.controllers.intervalBitrateRegulatorControllerFactory(
-                            bitrateRegulatorFactory = com.dimadesu.lifestreamer.bitrate.RtmpSendDurationBitrateRegulator.Factory(),
-                            bitrateRegulatorConfig = bitrateRegulatorConfig
-                        )
-                    }
-                }
-            }
+            streamConfigurationHelper.attachBitrateRegulator(
+                currentStreamer as? io.github.thibaultbee.streampack.core.streamers.single.IVideoSingleStreamer,
+                descriptor.type.sinkType,
+                TAG
+            )
             
             true
         } catch (e: TimeoutCancellationException) {

--- a/app/src/main/java/com/dimadesu/lifestreamer/utils/StreamConfigurationHelper.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/utils/StreamConfigurationHelper.kt
@@ -1,11 +1,49 @@
 package com.dimadesu.lifestreamer.utils
 
 import android.util.Log
+import com.dimadesu.lifestreamer.bitrate.AdaptiveSrtBitrateRegulatorController
+import com.dimadesu.lifestreamer.bitrate.RtmpSendDurationBitrateRegulator
 import com.dimadesu.lifestreamer.data.storage.DataStoreRepository
+import io.github.thibaultbee.streampack.core.elements.endpoints.MediaSinkType
+import io.github.thibaultbee.streampack.core.regulator.controllers.IBitrateRegulatorController
+import io.github.thibaultbee.streampack.core.regulator.controllers.intervalBitrateRegulatorControllerFactory
 import io.github.thibaultbee.streampack.core.streamers.single.IVideoSingleStreamer
 import kotlinx.coroutines.flow.first
 
 class StreamConfigurationHelper(private val storageRepository: DataStoreRepository) {
+
+    /**
+     * Builds the adaptive bitrate regulator factory for [sinkType] from stored settings, or
+     * `null` if adaptive bitrate is disabled for that sink type (or the sink type isn't SRT/RTMP).
+     */
+    suspend fun buildBitrateRegulatorFactoryOrNull(sinkType: MediaSinkType): IBitrateRegulatorController.Factory? {
+        if (sinkType != MediaSinkType.SRT && sinkType != MediaSinkType.RTMP) return null
+        val config = storageRepository.bitrateRegulatorConfigFlow.first() ?: return null
+        return if (sinkType == MediaSinkType.SRT) {
+            val mode = storageRepository.regulatorModeFlow.first()
+            AdaptiveSrtBitrateRegulatorController.Factory(bitrateRegulatorConfig = config, mode = mode)
+        } else {
+            intervalBitrateRegulatorControllerFactory(
+                bitrateRegulatorFactory = RtmpSendDurationBitrateRegulator.Factory(),
+                bitrateRegulatorConfig = config
+            )
+        }
+    }
+
+    /**
+     * Attaches a fresh adaptive bitrate regulator to [streamer] for [sinkType], resetting the
+     * encoder to the safe starting bitrate first so the regulator's first tick ramps up from
+     * 1 Mbps instead of cliff-dropping down from whatever bitrate was already active. Detaches
+     * any existing regulator (sets factory to `null`) if adaptive bitrate is disabled.
+     */
+    suspend fun attachBitrateRegulator(streamer: IVideoSingleStreamer?, sinkType: MediaSinkType, tag: String) {
+        if (streamer == null) return
+        val factory = buildBitrateRegulatorFactoryOrNull(sinkType)
+        if (factory != null) {
+            applySafeInitialBitrate(streamer, tag)
+        }
+        streamer.bitrateRegulatorControllerFactory = factory
+    }
 
     suspend fun applySafeInitialBitrate(streamer: IVideoSingleStreamer?, tag: String) {
         if (streamer == null) return


### PR DESCRIPTION
Matches Moblin's behavior where a fresh AdaptiveBitrate instance always starts at adaptiveBitrateStart (1 Mbps), created on every startNetStream() call - both initial start and reconnect.

applySafeInitialBitrate() was already called before the two full open()+startStream() paths, but two mid-stream re-attachment paths skipped it: toggling adaptive bitrate on/changing settings while already streaming (CameraStreamerService's config observer), and re-adding the regulator after video/audio source switches or RTMP-source hot-swap reconnects (PreviewViewModel's readdBitrateRegulatorIfNeeded()).

Without the reset, the encoder kept its prior (often high, slider-set) bitrate while the newly attached regulator's internal state started fresh at 1 Mbps, so the first regulator tick would cliff-drop the bitrate once its computed value diverged from that baseline - exactly the symptom of starting high then suddenly resetting to ~1 Mbps.