### PR TITLE
Refine SCREEN (MediaProjection) video source. Improve timestamp precision. Fix: Crash on Samsung S23 FE. New phones need to re-request MediaProjection permission for video

### DIFF
--- a/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
+++ b/app/src/main/java/com/dimadesu/lifestreamer/ui/main/PreviewViewModel.kt
@@ -52,6 +52,7 @@ import com.dimadesu.lifestreamer.rtmp.video.RTMPVideoSource
 import com.dimadesu.lifestreamer.uvc.UvcVideoSource
 import com.dimadesu.lifestreamer.audio.ConditionalAudioSourceFactory
 import io.github.thibaultbee.streampack.core.elements.sources.IMediaProjectionSource
+import io.github.thibaultbee.streampack.core.elements.sources.video.mediaprojection.MediaProjectionVideoSourceFactory
 import com.dimadesu.lifestreamer.utils.ObservableViewModel
 import com.dimadesu.lifestreamer.utils.dataStore
 import com.dimadesu.lifestreamer.utils.isEmpty
@@ -1892,7 +1893,14 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
             ?: streamingMediaProjection
             ?: mediaProjectionHelper.getMediaProjection()
 
-        if (existingProjection != null) {
+        // Android invalidates a MediaProjection token for createVirtualDisplay once its virtual
+        // display has been stopped. Reusing an exhausted token here would crash, so fall through
+        // to requesting a fresh one instead when screen video capture is active.
+        val needsFreshProjectionForVideo = _isScreenSource.value == true &&
+                existingProjection != null &&
+                MediaProjectionVideoSourceFactory.isProjectionExhaustedForVideo(existingProjection)
+
+        if (existingProjection != null && !needsFreshProjectionForVideo) {
             Log.i(TAG, "startStreamWithMediaProjection: reusing existing MediaProjection token")
             streamingMediaProjection = existingProjection
             startupMediaProjection = existingProjection
@@ -3993,10 +4001,11 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                 // Switching to Screen Source
                 Log.i(TAG, "Switching to Screen source")
 
+                val cachedProjection = streamingMediaProjection ?: startupMediaProjection ?: mediaProjectionHelper.getMediaProjection()
+                // A cached token that already had its virtual display stopped can't be reused for
+                // createVirtualDisplay — Android throws a SecurityException. Request a fresh one instead.
                 val needProjection = android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q
-                        && startupMediaProjection == null
-                        && streamingMediaProjection == null
-                        && mediaProjectionHelper.getMediaProjection() == null
+                        && (cachedProjection == null || MediaProjectionVideoSourceFactory.isProjectionExhaustedForVideo(cachedProjection))
 
                 val doScreenSwitch: suspend (MediaProjection?) -> Unit = { proj ->
                     _isScreenSource.postValue(true)
@@ -4032,8 +4041,7 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
                         _streamerErrorLiveData.postValue("MediaProjection permission required")
                     }
                 } else {
-                    val projection = streamingMediaProjection ?: startupMediaProjection ?: mediaProjectionHelper.getMediaProjection()
-                    doScreenSwitch(projection)
+                    doScreenSwitch(cachedProjection)
                 }
             } else {
                 // Switching off Screen Source
@@ -4072,10 +4080,10 @@ class PreviewViewModel(private val application: Application) : ObservableViewMod
         if (useCfr) {
             val fps = videoConfigLiveData.value?.fps ?: 30
             Log.i(TAG, "switchToMediaProjectionVideoSource: Switching to CFR MediaProjection source with fps=$fps")
-            currentStreamer.setVideoSource(io.github.thibaultbee.streampack.core.elements.sources.video.mediaprojection.MediaProjectionVideoSourceFactory(projection, fps))
+            currentStreamer.setVideoSource(MediaProjectionVideoSourceFactory(projection, fps))
         } else {
             Log.i(TAG, "switchToMediaProjectionVideoSource: Switching to default MediaProjection source")
-            currentStreamer.setVideoSource(io.github.thibaultbee.streampack.core.elements.sources.video.mediaprojection.MediaProjectionVideoSourceFactory(projection))
+            currentStreamer.setVideoSource(MediaProjectionVideoSourceFactory(projection))
         }
         
         readdBitrateRegulatorIfNeeded()


### PR DESCRIPTION
Before SCREEN video source LifeStreamer (LS) was on StreamPack's (SP) `update-to-3.2.0` branch.

For SCREEN source in StreamPack fork I branched out from `update-to-3.2.0` branch to `update-to-3.2.0+screen-video-source` and added 6 additional commits.

I want to keep that granular original git history so `update-to-3.2.0+screen-video-source`  will be kept in the fork.

In this commit:
- Switched SP in LS back to `update-to-3.2.0` branch.
- Squashed 6 additional commits into 3 commits.
- Added them on top of `update-to-3.2.0` branch.
- Added more commits on top of those.
  - Timestamp precision - good.
  - Surface hardening - more like no.
  - Etc.